### PR TITLE
Potential fix for code scanning alert no. 7: Clear-text logging of sensitive information

### DIFF
--- a/src/orbit/ai/sentimentor.py
+++ b/src/orbit/ai/sentimentor.py
@@ -23,7 +23,7 @@ def fetch_news():
         return []  # or handle this error case gracefully
 
     if 'error' in news_data:
-        print("Error in News API response:", news_data['error'])
+        print("Error in News API response. Check server logs or monitoring for details.")
         return []
     print("Successfully fetched news data.")
     articles = []


### PR DESCRIPTION
Potential fix for [https://github.com/ipankaj18/Orbit/security/code-scanning/7](https://github.com/ipankaj18/Orbit/security/code-scanning/7)

In general, to fix clear‑text logging of sensitive information, avoid logging full error payloads or any fields that could contain secrets (API keys, tokens, passwords, etc.). Instead, log high‑level status information (HTTP status codes, generic messages) and, if necessary, a sanitized version of the error that omits or masks sensitive values.

For this specific code, the minimal non‑breaking fix is to stop printing `news_data['error']` directly. We can either: (a) log only a generic error message, or (b) log a limited, sanitized portion of the error. Since we don’t know the exact schema and must not risk leaking the API key, the safest fix is to replace `print("Error in News API response:", news_data['error'])` with a generic message that doesn’t include the error content. Optionally, we can log the HTTP status code that we already have earlier, but not the body.

Concretely, in `src/orbit/ai/sentimentor.py`, around line 26, update the `print` call inside the `if 'error' in news_data:` block to remove the interpolation of `news_data['error']`. No new imports or helper functions are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
