### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/static-checker.yml
+++ b/.github/workflows/static-checker.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ipankaj18/Orbit/security/code-scanning/2](https://github.com/ipankaj18/Orbit/security/code-scanning/2)

To fix the problem, explicitly define restricted `GITHUB_TOKEN` permissions in the workflow. The safest, least-privilege configuration here is to grant read-only access to repository contents (so `actions/checkout` can function) and nothing else. This can be done at the workflow root so it applies to all jobs, or at the job level. Since there is only one job (`build`), either is fine; adding it at the root documents intent clearly and will scale if more jobs are added.

The concrete change: in `.github/workflows/static-checker.yml`, add a `permissions:` block near the top-level (e.g., after `name:` or after `on:`) specifying `contents: read`. No imports or additional methods are required, as this is purely a YAML configuration change. Existing functionality will be preserved: `actions/checkout@v4` works with `contents: read`, and the rest of the steps operate only on the checked-out code and local environment.

Specifically, change the top of the file to include:

```yaml
name: Static Checker

on:
  ...
permissions:
  contents: read
```

or equivalently place `permissions:` right after `name:`; in YAML, order at the root doesn’t affect behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
