### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/ipankaj18/Orbit/security/code-scanning/1](https://github.com/ipankaj18/Orbit/security/code-scanning/1)

In general, to fix this problem you should explicitly set a `permissions` block in the workflow (either at the top level or per job) that grants only the minimal access the job needs. For a unit-test workflow that only checks out code, installs dependencies, and runs tests, read-only access to repository contents is sufficient; other scopes (issues, pull-requests, packages, etc.) can remain at their implicit default of `none`.

The best fix here, without changing functionality, is to add a `permissions` block at the workflow root (between `name:` and `on:` or between `on:` and `jobs:`) that sets `contents: read`. This will apply to all jobs in the workflow (currently just `test`) and constrain the `GITHUB_TOKEN` to read-only repository contents, which is enough for `actions/checkout` and does not interfere with Python/Poetry/test steps, which do not use the token. No imports or additional methods are needed since this is a YAML configuration change only.

Concretely, edit `.github/workflows/unit-tests.yml` to insert:

```yaml
permissions:
  contents: read
```

near the top of the file. No other lines need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
