### PR TITLE
fix: make NewsSentiment fields optional to handle incomplete LLM output (closes #345)

### DIFF
--- a/src/orbit/market_intelligence/sentimental_workflow.py
+++ b/src/orbit/market_intelligence/sentimental_workflow.py
@@ -104,9 +104,9 @@ class NewsSentiment(BaseModel):
         confidence: Confidence score between 0 and 1
         explanation: Brief textual explanation of reasoning
     """
-    sentiment: SentimentType
-    confidence: float = Field(ge=0.0, le=1.0)
-    explanation: str
+    sentiment: Optional[SentimentType] = None
+    confidence: float = Field(default=0.0, ge=0.0, le=1.0)
+    explanation: Optional[str] = None
 
 
 class SentimentWorkflow(ExceptionManager):


### PR DESCRIPTION
## What
The LLM sometimes returns news sentiment JSON without the required `sentiment` and `explanation` fields, causing a pydantic ValidationError that crashes the pipeline.

## Fix
Made `sentiment` and `explanation` fields optional in the `NewsSentiment` model with `None` defaults (sentiment as `Optional[SentimentType]`, explanation as `Optional[str]`). Set `confidence` default to 0.0. This allows the workflow to gracefully handle incomplete LLM responses and continue processing.

Closes #345