### PR TITLE
fix: sanitize LLM output key corruption in OpenRouter client (closes #440)

### DIFF
--- a/src/orbit/market_intelligence/llm/openrouter_client.py
+++ b/src/orbit/market_intelligence/llm/openrouter_client.py
@@ -84,6 +84,8 @@ class OpenRouterClient:
             if extracted_response is None:
                 logger.warning("Extracted Response is None")
                 continue
+            # Sanitize known corrupted key(s) from LLM output
+            extracted_response = extracted_response.replace('"sentiment тәс"', '"sentiment"')
             return extracted_response
 
         # Should never be reached, but guard


### PR DESCRIPTION
## What
When OpenRouter routes to model openai/gpt-oss-20b:free, the LLM returns a JSON with the key `sentiment тәс` instead of `sentiment`. This causes pydantic.ValidationError in sentimental_workflow.py because the expected field `sentiment` is missing.

## Fix
Add a simple string replacement in OpenRouterClient.invoke() to replace the corrupted key `sentiment тәс` with `sentiment` before returning the response. This is a minimal, targeted fix that addresses the immediate issue while waiting for a deeper investigation into why the prompt template introduces non-ASCII characters.

Closes #440