### PR TITLE
consolidate strategies and add safe adaptive trading

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Safe default. Values: paper, testnet, live
+ORBIT_EXECUTION_MODE=paper
+
+# Binance Futures Testnet (required only for testnet mode)
+BINANCE_TESTNET_API_KEY=
+BINANCE_TESTNET_SECRET_KEY=
+BINANCE_FUTURES_TESTNET_URL=https://demo-fapi.binance.com
+
+# Production credentials (required only for live mode)
+BINANCE_API_KEY=
+BINANCE_SECRET_KEY=
+# Live mode remains locked unless this exact acknowledgement is present.
+ORBIT_LIVE_TRADING_ACK=
+
+# Optional Discord outputs. Empty values disable the corresponding notification.
+ORBIT_WEBHOOK_LOGS=
+ORBIT_WEBHOOK_ALERTS=
+ORBIT_WEBHOOK_SIGNAL=
+ORBIT_WEBHOOK_EXCEPTION=
+ORBIT_WEBHOOK_MARKET_SENTIMENT=
+
+# Existing external services
+MONGODB_URI=mongodb://localhost:27017
+REDIS_HOST=localhost
+REDIS_PORT=6379
+REDIS_DB=0
+ORBIT_LOG_FILE=app.log

--- a/.github/scripts/ai_client.py
+++ b/.github/scripts/ai_client.py
@@ -2,6 +2,13 @@ import os
 from openai import OpenAI
 import logging
 
+
+def _message_text(response) -> str:
+    """Return normalized model text; providers may legally return null content."""
+    if not response.choices:
+        return ""
+    return (response.choices[0].message.content or "").strip()
+
 class AIClient:
     def __init__(self, model="o3-mini"):
         api_key = os.environ.get("OPENAI_API_KEY")
@@ -20,7 +27,7 @@ class AIClient:
             ],
         )
 
-        return response.choices[0].message.content.strip()
+        return _message_text(response)
 
 
 class GitHubModelClient:
@@ -48,7 +55,7 @@ class GitHubModelClient:
             top_p=1.0,
         )
 
-        return response.choices[0].message.content.strip()
+        return _message_text(response)
 
 
 class OpenRouterClient:
@@ -74,7 +81,7 @@ class OpenRouterClient:
             temperature=1.0,
         )
 
-        return response.choices[0].message.content.strip()
+        return _message_text(response)
 
 class FallbackClient:
     def __init__(self):

--- a/.github/workflows/static-checker.yml
+++ b/.github/workflows/static-checker.yml
@@ -41,7 +41,6 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install --no-interaction --no-ansi
-          poetry run pip install -r strategy-requirements.txt
 
       - name: Analysing the code with pylint
         run: |

--- a/.github/workflows/static-checker.yml
+++ b/.github/workflows/static-checker.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Install dependencies
         run: |
           poetry install --no-interaction --no-ansi
+          poetry run pip install -r strategy-requirements.txt
 
       - name: Analysing the code with pylint
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,7 +55,6 @@ jobs:
         run: |
           poetry config virtualenvs.in-project true
           poetry install --no-interaction --no-ansi
-          poetry run pip install -r strategy-requirements.txt
 
       - name: Run Unit Tests with Coverage
         run: |

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -15,6 +15,9 @@ on:
 
   schedule:
     - cron: "0 */6 * * *" 
+  push:
+    branches:
+      - main
 
 jobs:
   test:
@@ -52,6 +55,7 @@ jobs:
         run: |
           poetry config virtualenvs.in-project true
           poetry install --no-interaction --no-ansi
+          poetry run pip install -r strategy-requirements.txt
 
       - name: Run Unit Tests with Coverage
         run: |

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Start the application with:
 ```
 poetry run orbit
 ```
+Orbit defaults to `paper` mode, which blocks exchange order submission. For a
+safe Binance Futures Testnet run, copy `.env.example`, set
+`ORBIT_EXECUTION_MODE=testnet`, and provide dedicated Testnet credentials. Live
+mode is separately locked. See
+[`docs/operations/SAFE_ADAPTIVE_TRADING.md`](docs/operations/SAFE_ADAPTIVE_TRADING.md)
+for accounting, risk policy, EC2 rollout, and strategy-promotion procedures.
 This command launches `BinanceAutomation`, the top-level trading automation controller found in `src/orbit/core/main.py`. It orchestrates three long-running daemon threads:
 
 1. **Signal Analysis** — aligns to 15-minute candle boundaries, generates and processes trading signals via `SignalAnalyzer`, and sleeps for 900 seconds (15 minutes) between cycles.

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Orbit is an AI-based trading framework that bridges research experimentation and
 - **Market Intelligence:** Harness Reddit and news sentiment data for actionable insights using LLM-powered analysis.
 - **Automated Trading:** Execute and monitor Binance Futures trades with precision, including SL/TP lifecycle management.
 - **Modular Design:** Easily integrate custom strategies via a lazy-loading strategy registry.
+- **Self-contained Strategies:** Production BTC, ETH, and BCH strategies are versioned and deployed with Orbit; no private runtime repository is required.
 - **Research to Production:** Smooth transition from trading ideas to live trading with contradict simulation support.
 
 ## Setup and Installation
@@ -44,6 +45,8 @@ safe Binance Futures Testnet run, copy `.env.example`, set
 mode is separately locked. See
 [`docs/operations/SAFE_ADAPTIVE_TRADING.md`](docs/operations/SAFE_ADAPTIVE_TRADING.md)
 for accounting, risk policy, EC2 rollout, and strategy-promotion procedures.
+The strategy migration and ownership boundary are documented in
+[`docs/architecture/STRATEGY_CONSOLIDATION.md`](docs/architecture/STRATEGY_CONSOLIDATION.md).
 This command launches `BinanceAutomation`, the top-level trading automation controller found in `src/orbit/core/main.py`. It orchestrates three long-running daemon threads:
 
 1. **Signal Analysis** — aligns to 15-minute candle boundaries, generates and processes trading signals via `SignalAnalyzer`, and sleeps for 900 seconds (15 minutes) between cycles.

--- a/config/__init__.py
+++ b/config/__init__.py
@@ -1,6 +1,7 @@
 from enum import Enum
 import logging
 import logging.config
+import os
 import yaml
 
 class TradeType(Enum):
@@ -29,9 +30,11 @@ TRAILING_STOPLOSS = {
     "XRPUSDT": False
 }
 
-# Load YAML config
-with open("config/logging_config.yaml", "r") as f:
+# Load YAML config independently of the process working directory.
+_CONFIG_DIR = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(_CONFIG_DIR, "logging_config.yaml"), "r", encoding="utf-8") as f:
     config = yaml.safe_load(f.read())
+    config["handlers"]["file"]["filename"] = os.getenv("ORBIT_LOG_FILE", "app.log")
     logging.config.dictConfig(config)
 
 # Get your logger

--- a/config/config.json
+++ b/config/config.json
@@ -15,6 +15,13 @@
       "stop_loss_percent":1
     },
     "FUTURE_LEVERAGE": 2,
+    "risk_policy": {
+      "max_leverage": 5,
+      "max_position_notional_pct": 0.25,
+      "max_risk_per_trade_pct": 0.01,
+      "max_daily_loss_pct": 0.02,
+      "min_reward_risk_ratio": 1.5
+    },
     "trading_pairs": [ "BTCUSDT", "ETHUSDT", "BCHUSDT"], 
     "trade_checker_pair": [ "BCHUSDT", "BTCUSDT", "BNBUSDT", "ETHUSDT", "MKRUSDT", "LTCUSDT", "SOLUSDT", "ATOMUSDT", "XRPUSDT"],
     "trading_pairs_precision":{

--- a/config/strategies.yaml
+++ b/config/strategies.yaml
@@ -1,9 +1,12 @@
 strategies:
   BCHUSDT:
     strategy: orbit_strategies.strategies.reversal_strategy.BollingerAdaptiveReversalStrategyBCH
+    expected_package_version: "1.0.4"
 
   ETHUSDT:
     strategy: orbit_strategies.strategies.Agglo_strategy.Agglo_ETHERIUM
+    expected_package_version: "1.0.4"
 
   BTCUSDT:
     strategy: orbit_strategies.strategies.swing_strategy.SwingStrategyBTC
+    expected_package_version: "1.0.4"

--- a/config/strategies.yaml
+++ b/config/strategies.yaml
@@ -1,12 +1,9 @@
 strategies:
   BCHUSDT:
-    strategy: orbit_strategies.strategies.reversal_strategy.BollingerAdaptiveReversalStrategyBCH
-    expected_package_version: "1.0.4"
+    strategy: orbit.strategies.reversal_strategy.BollingerAdaptiveReversalStrategyBCH
 
   ETHUSDT:
-    strategy: orbit_strategies.strategies.Agglo_strategy.Agglo_ETHERIUM
-    expected_package_version: "1.0.4"
+    strategy: orbit.strategies.agglo_strategy.Agglo_ETHERIUM
 
   BTCUSDT:
-    strategy: orbit_strategies.strategies.swing_strategy.SwingStrategyBTC
-    expected_package_version: "1.0.4"
+    strategy: orbit.strategies.swing_strategy.SwingStrategyBTC

--- a/docs/architecture/STRATEGY_CONSOLIDATION.md
+++ b/docs/architecture/STRATEGY_CONSOLIDATION.md
@@ -1,0 +1,43 @@
+# Strategy consolidation
+
+## Decision
+
+The production strategy surface formerly loaded from the private
+`Orbit-Strategies` repository is now part of Orbit. The private repository is a
+legacy research archive and no longer participates in installation, CI, Testnet,
+or EC2 deployment.
+
+## Migrated production surface
+
+| Symbol | Production class | Orbit module |
+|---|---|---|
+| BTCUSDT | `SwingStrategyBTC` | `orbit.strategies.swing_strategy` |
+| ETHUSDT | `Agglo_ETHERIUM` | `orbit.strategies.agglo_strategy` |
+| BCHUSDT | `BollingerAdaptiveReversalStrategyBCH` | `orbit.strategies.reversal_strategy` |
+
+The shared `Strategy` base now contains the ATR and EMA helpers required by
+those implementations. `orbit.backtesting` contains the walk-forward validation
+engine. Orbit's existing Discord manager and chart utility are reused; the
+legacy repository's duplicated notification code and embedded webhook values
+were deliberately excluded.
+
+## Excluded legacy surface
+
+- research notebooks and generated datasets
+- experimental reinforcement-learning and neural-network programs
+- one-off backtesting scripts
+- inactive symbol strategies
+- duplicated configuration, Discord, and utility modules
+- caches, charts, and generated artifacts
+
+## Adding or promoting a strategy
+
+1. Implement the production `Strategy` contract inside `src/orbit/strategies/`.
+2. Add its import path to `config/strategies.yaml`.
+3. Add deterministic signal tests and walk-forward tests.
+4. Validate fees, slippage, drawdown, and out-of-sample behavior.
+5. Run the exact Orbit commit on Futures Testnet.
+6. Promote that Orbit commit through the guarded live deployment workflow.
+
+This removes cross-repository authentication and version drift: the signal,
+risk decision, order, and resulting performance all map to one commit.

--- a/docs/operations/SAFE_ADAPTIVE_TRADING.md
+++ b/docs/operations/SAFE_ADAPTIVE_TRADING.md
@@ -10,24 +10,17 @@ OHLCV + sentiment -> versioned strategy -> decision ledger -> risk guard
 -> Testnet order -> Binance income ledger -> performance report -> promotion review
 ```
 
-## Repositories
+## Repository ownership
 
-- `Orbit` owns data collection, sentiment filters, risk policy, order execution,
-  trade monitoring, accounting, and notifications.
-- `Orbit-Strategies` owns signal generation. Version 1.0.4 is currently expected.
+Orbit owns the complete production runtime: data collection, the three active
+strategies, sentiment filters, risk policy, execution, monitoring, accounting,
+notifications, and backtesting. `Orbit-Strategies` is a legacy research archive
+and is not installed by CI or EC2.
 
-Deploy both repositories at explicit commits. Do not use an unpinned editable
-checkout on EC2. The running commit and strategy package version must be included
-in deployment logs.
-
-Install the audited strategy commit inside Orbit's Poetry environment with:
-
-```bash
-poetry run pip install -r strategy-requirements.txt
-```
-
-When promoting a strategy release, update the commit in that file and the
-`expected_package_version` in `config/strategies.yaml` together.
+Production strategies live in `src/orbit/strategies/`. Every strategy change is
+therefore versioned by the same Orbit commit that executes it. Experimental
+research should not be imported into the runtime until it is reduced to the
+production strategy contract and reviewed in Orbit.
 
 ## Execution environments
 
@@ -84,10 +77,10 @@ order path fails closed instead of trading with a stale daily-loss value.
 ## EC2 rollout checklist
 
 1. Back up `.env`, MongoDB, and the current deployed commit IDs.
-2. Install the pinned `Orbit-Strategies` release and Orbit lockfile.
+2. Install Orbit from its lockfile; no second repository is required.
 3. Set `ORBIT_EXECUTION_MODE=testnet` and Testnet-only credentials.
 4. Start Redis and MongoDB, then start Orbit from the repository root.
-5. Confirm logs show the Testnet mode and expected strategy version.
+5. Confirm logs show Testnet mode and the expected Orbit commit.
 6. Confirm `trade_decisions` receives no-signal and rejected decisions.
 7. Place only deliberately triggered Testnet scenarios and reconcile orders in
    the Binance Testnet UI.
@@ -103,7 +96,7 @@ release symlink, restart, and verify process health. If startup or health checks
 fail, restore the prior symlink and restart the previous release. A webhook must
 not run `git pull` directly inside the active environment.
 
-Minimum deployment output should include deployment ID, both commit hashes,
+Minimum deployment output should include deployment ID, the Orbit commit hash,
 execution mode, test result, service restart result, and rollback result. Keep
 these events in journald/CloudWatch and send failures to `ORBIT_WEBHOOK_ALERTS`.
 
@@ -114,7 +107,7 @@ minimum profit factor, maximum daily loss, slippage allowance, and comparison
 benchmark. Promotion remains a human-approved configuration/version change.
 Automated rollback is allowed when a hard risk or health threshold is breached.
 
-Use `orbit_strategies.backtesting.WalkForwardBacktester` for the first validation
+Use `orbit.backtesting.WalkForwardBacktester` for the first validation
 stage. It exercises the production signal method using historical prefixes and
 includes fees, slippage, conservative same-candle exits, equity sizing, profit
 factor, and maximum drawdown. Strategy-specific research notebooks remain

--- a/docs/operations/SAFE_ADAPTIVE_TRADING.md
+++ b/docs/operations/SAFE_ADAPTIVE_TRADING.md
@@ -1,0 +1,121 @@
+# Safe adaptive trading and performance operations
+
+## Purpose
+
+Orbit's adaptation loop improves risk-adjusted execution without allowing a
+strategy or an AI process to rewrite live trading behavior autonomously.
+
+```text
+OHLCV + sentiment -> versioned strategy -> decision ledger -> risk guard
+-> Testnet order -> Binance income ledger -> performance report -> promotion review
+```
+
+## Repositories
+
+- `Orbit` owns data collection, sentiment filters, risk policy, order execution,
+  trade monitoring, accounting, and notifications.
+- `Orbit-Strategies` owns signal generation. Version 1.0.4 is currently expected.
+
+Deploy both repositories at explicit commits. Do not use an unpinned editable
+checkout on EC2. The running commit and strategy package version must be included
+in deployment logs.
+
+Install the audited strategy commit inside Orbit's Poetry environment with:
+
+```bash
+poetry run pip install -r strategy-requirements.txt
+```
+
+When promoting a strategy release, update the commit in that file and the
+`expected_package_version` in `config/strategies.yaml` together.
+
+## Execution environments
+
+`ORBIT_EXECUTION_MODE` controls the order boundary:
+
+- `paper` is the default and blocks all Binance order submissions.
+- `testnet` uses `BINANCE_TESTNET_API_KEY`, `BINANCE_TESTNET_SECRET_KEY`, and
+  `https://demo-fapi.binance.com` by default.
+- `live` uses production credentials and additionally requires
+  `ORBIT_LIVE_TRADING_ACK=I_UNDERSTAND`.
+
+Testnet and production credentials must be different and should be loaded from
+AWS Systems Manager Parameter Store or Secrets Manager by the EC2 service. Never
+write credentials or webhook URLs into Git.
+
+## Decision ledger
+
+MongoDB collection `trade_decisions` stores accepted, rejected, no-signal, and
+error decisions. Each entry includes a UUID, symbol, fully qualified strategy
+class, strategy package version, execution mode, sentiment, pattern, prices,
+outcome, and reason. This makes rejected opportunities measurable and connects
+returns to the exact signal implementation.
+
+## Performance accounting
+
+MongoDB collection `futures_income` upserts exchange income rows by transaction
+and income type. The daily report calculates:
+
+```text
+net P&L = realized P&L + commission + funding fees + other income
+return % = net P&L / opening equity * 100
+```
+
+Binance represents commissions and paid funding as negative income, so they are
+added rather than subtracted a second time. `PerformanceReporterThread` syncs and
+reports the last 24 hours when Orbit starts and every 24 hours thereafter.
+
+## Risk policy
+
+`config/config.json` contains policy independent of strategy logic:
+
+- maximum leverage: 5
+- maximum position notional: 25% of wallet equity
+- maximum risk at stop: 1% of wallet equity per trade
+- daily net-loss halt: 2% of wallet equity
+- minimum expected reward/risk: 1.5
+
+Position size is derived from wallet equity and stop distance. Exchange minimums
+do not override policy: if a minimum-sized order exceeds a limit, it is rejected.
+Immediately before an order, the daily loss gate refreshes today's income from
+Binance and persists it locally. If this authenticated synchronization fails, the
+order path fails closed instead of trading with a stale daily-loss value.
+
+## EC2 rollout checklist
+
+1. Back up `.env`, MongoDB, and the current deployed commit IDs.
+2. Install the pinned `Orbit-Strategies` release and Orbit lockfile.
+3. Set `ORBIT_EXECUTION_MODE=testnet` and Testnet-only credentials.
+4. Start Redis and MongoDB, then start Orbit from the repository root.
+5. Confirm logs show the Testnet mode and expected strategy version.
+6. Confirm `trade_decisions` receives no-signal and rejected decisions.
+7. Place only deliberately triggered Testnet scenarios and reconcile orders in
+   the Binance Testnet UI.
+8. Confirm `futures_income` includes realized P&L, commissions, and funding.
+9. Observe at least the agreed number of independent trades and market regimes.
+10. Review drawdown and net performance before any live-mode discussion.
+
+## Deployment health and rollback
+
+The EC2 webhook should perform a staged deployment: fetch explicit commits,
+install into a new virtual environment, run offline tests, stop Orbit, switch the
+release symlink, restart, and verify process health. If startup or health checks
+fail, restore the prior symlink and restart the previous release. A webhook must
+not run `git pull` directly inside the active environment.
+
+Minimum deployment output should include deployment ID, both commit hashes,
+execution mode, test result, service restart result, and rollback result. Keep
+these events in journald/CloudWatch and send failures to `ORBIT_WEBHOOK_ALERTS`.
+
+## Promotion criteria
+
+Define these before collecting results: minimum trade count, maximum drawdown,
+minimum profit factor, maximum daily loss, slippage allowance, and comparison
+benchmark. Promotion remains a human-approved configuration/version change.
+Automated rollback is allowed when a hard risk or health threshold is breached.
+
+Use `orbit_strategies.backtesting.WalkForwardBacktester` for the first validation
+stage. It exercises the production signal method using historical prefixes and
+includes fees, slippage, conservative same-candle exits, equity sizing, profit
+factor, and maximum drawdown. Strategy-specific research notebooks remain
+exploratory evidence and are not deployment gates by themselves.

--- a/src/orbit/backtesting/__init__.py
+++ b/src/orbit/backtesting/__init__.py
@@ -1,0 +1,6 @@
+"""Reusable production-strategy backtesting primitives."""
+
+from .engine import BacktestReport, TradeResult, WalkForwardBacktester
+
+__all__ = ["BacktestReport", "TradeResult", "WalkForwardBacktester"]
+

--- a/src/orbit/backtesting/engine.py
+++ b/src/orbit/backtesting/engine.py
@@ -1,0 +1,152 @@
+"""Conservative walk-forward backtester for the production signal contract."""
+
+from dataclasses import asdict, dataclass
+from typing import Any, Callable
+
+import pandas as pd
+
+
+@dataclass(frozen=True)
+class TradeResult:
+    side: str
+    entry_time: Any
+    exit_time: Any
+    entry_price: float
+    exit_price: float
+    quantity: float
+    gross_pnl: float
+    costs: float
+    net_pnl: float
+    outcome: str
+    pattern: str
+
+
+@dataclass(frozen=True)
+class BacktestReport:
+    starting_equity: float
+    final_equity: float
+    net_pnl: float
+    return_pct: float
+    trades: int
+    wins: int
+    losses: int
+    win_rate: float
+    profit_factor: float | None
+    max_drawdown_pct: float
+    results: tuple[TradeResult, ...]
+
+    def to_dict(self) -> dict[str, Any]:
+        result = asdict(self)
+        result["results"] = [asdict(item) for item in self.results]
+        return result
+
+
+class WalkForwardBacktester:
+    """Evaluate a strategy on prefixes only, preventing future-data access.
+
+    A single position is allowed at a time. If stop and target are touched in
+    the same candle, the stop is chosen as the conservative outcome.
+    """
+
+    def __init__(
+        self,
+        strategy_factory: Callable[[pd.DataFrame], Any],
+        *,
+        starting_equity: float = 10_000.0,
+        risk_per_trade_pct: float = 0.01,
+        fee_rate: float = 0.0004,
+        slippage_bps: float = 2.0,
+    ) -> None:
+        if starting_equity <= 0 or not 0 < risk_per_trade_pct <= 1:
+            raise ValueError("Invalid equity or risk percentage")
+        self.strategy_factory = strategy_factory
+        self.starting_equity = starting_equity
+        self.risk_per_trade_pct = risk_per_trade_pct
+        self.fee_rate = fee_rate
+        self.slippage = slippage_bps / 10_000
+
+    def run(self, data: pd.DataFrame, *, symbol: str, warmup_bars: int = 250) -> BacktestReport:
+        required = {"open", "high", "low", "close", "volume"}
+        if not required.issubset(data.columns):
+            raise ValueError(f"Data must contain {sorted(required)}")
+        if not data.index.is_monotonic_increasing:
+            raise ValueError("Data index must be sorted oldest to newest")
+
+        equity = self.starting_equity
+        peak = equity
+        max_drawdown = 0.0
+        results: list[TradeResult] = []
+        index = max(warmup_bars, 1)
+
+        while index < len(data) - 1:
+            strategy = self.strategy_factory(data.iloc[: index + 1].copy())
+            signal = strategy.generate_signals(symbol=symbol)
+            if not signal or signal.get("signal") not in ("BUY", "SELL"):
+                index += 1
+                continue
+
+            side = signal["signal"]
+            raw_entry = float(signal.get("entry_price") or data["close"].iloc[index])
+            stop = float(signal["stop_loss"])
+            target = float(signal["take_profit"])
+            if (side == "BUY" and not stop < raw_entry < target) or (
+                side == "SELL" and not target < raw_entry < stop
+            ):
+                index += 1
+                continue
+
+            entry = raw_entry * (1 + self.slippage if side == "BUY" else 1 - self.slippage)
+            risk_per_unit = abs(entry - stop)
+            quantity = (equity * self.risk_per_trade_pct) / risk_per_unit
+            exit_index, raw_exit, outcome = self._resolve_exit(
+                data, index + 1, side, stop, target
+            )
+            exit_price = raw_exit * (
+                1 - self.slippage if side == "BUY" else 1 + self.slippage
+            )
+            direction = 1 if side == "BUY" else -1
+            gross = (exit_price - entry) * quantity * direction
+            costs = (entry + exit_price) * quantity * self.fee_rate
+            net = gross - costs
+            equity += net
+            peak = max(peak, equity)
+            max_drawdown = max(max_drawdown, (peak - equity) / peak)
+            results.append(TradeResult(
+                side=side, entry_time=data.index[index], exit_time=data.index[exit_index],
+                entry_price=entry, exit_price=exit_price, quantity=quantity,
+                gross_pnl=gross, costs=costs, net_pnl=net, outcome=outcome,
+                pattern=str(signal.get("pattern", "unknown")),
+            ))
+            index = exit_index + 1
+
+        wins = sum(result.net_pnl > 0 for result in results)
+        losses = sum(result.net_pnl <= 0 for result in results)
+        gross_profit = sum(max(result.net_pnl, 0) for result in results)
+        gross_loss = abs(sum(min(result.net_pnl, 0) for result in results))
+        profit_factor = gross_profit / gross_loss if gross_loss else None
+        return BacktestReport(
+            starting_equity=self.starting_equity,
+            final_equity=equity,
+            net_pnl=equity - self.starting_equity,
+            return_pct=((equity / self.starting_equity) - 1) * 100,
+            trades=len(results), wins=wins, losses=losses,
+            win_rate=(wins / len(results) * 100) if results else 0.0,
+            profit_factor=profit_factor, max_drawdown_pct=max_drawdown * 100,
+            results=tuple(results),
+        )
+
+    @staticmethod
+    def _resolve_exit(
+        data: pd.DataFrame, start: int, side: str, stop: float, target: float
+    ) -> tuple[int, float, str]:
+        for position in range(start, len(data)):
+            low = float(data["low"].iloc[position])
+            high = float(data["high"].iloc[position])
+            stop_hit = low <= stop if side == "BUY" else high >= stop
+            target_hit = high >= target if side == "BUY" else low <= target
+            if stop_hit:
+                return position, stop, "stop"
+            if target_hit:
+                return position, target, "target"
+        return len(data) - 1, float(data["close"].iloc[-1]), "end_of_data"
+

--- a/src/orbit/core/authentication_manager.py
+++ b/src/orbit/core/authentication_manager.py
@@ -21,6 +21,7 @@ from binance.um_futures import UMFutures
 
 from config.config import load_config
 from orbit.core.exception_manager import ExceptionManager
+from orbit.core.execution import ExecutionSettings
 
 logger = logging.getLogger("Orbit")
 
@@ -36,9 +37,14 @@ def _build_spot_client(api_key: Optional[str], secret_key: Optional[str]) -> Spo
     return client
 
 
-def _build_futures_client(api_key: Optional[str], secret_key: Optional[str]) -> UMFutures:
+def _build_futures_client(
+    api_key: Optional[str], secret_key: Optional[str], base_url: Optional[str] = None
+) -> UMFutures:
     """Create a :class:`UMFutures` client."""
-    return UMFutures(api_key, secret=secret_key)
+    kwargs: Dict[str, Any] = {"key": api_key, "secret": secret_key}
+    if base_url:
+        kwargs["base_url"] = base_url
+    return UMFutures(**kwargs)
 
 
 @dataclass
@@ -70,16 +76,20 @@ class AuthenticationManager(ExceptionManager):
         spot_client: Optional[Spot] = None,
         futures_client: Optional[UMFutures] = None,
         config: Optional[Dict[str, Any]] = None,
+        execution_settings: Optional[ExecutionSettings] = None,
     ) -> None:
         super().__init__()
 
         self.config: Dict[str, Any] = config if config is not None else load_config()
 
-        api_key = os.getenv("BINANE_API_KEY")
-        secret_key = os.getenv("SECRET_KEY")
+        self.execution_settings = execution_settings or ExecutionSettings.from_env()
+        api_key = self.execution_settings.api_key
+        secret_key = self.execution_settings.secret_key
 
         self.client: Spot = spot_client or _build_spot_client(api_key, secret_key)
-        self.future_client: UMFutures = futures_client or _build_futures_client(api_key, secret_key)
+        self.future_client: UMFutures = futures_client or _build_futures_client(
+            api_key, secret_key, self.execution_settings.futures_base_url
+        )
 
         self.trading_pairs: List[str] = self.config["trading_pairs"]
         self.trade_checker_pair: List[str] = self.config["trade_checker_pair"]

--- a/src/orbit/core/discord_manager.py
+++ b/src/orbit/core/discord_manager.py
@@ -53,7 +53,8 @@ class URLS:
         """
         if key not in cls.WEBHOOKS:
             raise ValueError(f"Invalid webhook key: {key}")
-        return cls.WEBHOOKS[key]
+        env_key = f"ORBIT_WEBHOOK_{key.upper()}"
+        return os.getenv(env_key) or cls.WEBHOOKS[key]
 
 
 class DiscordManager:
@@ -105,6 +106,9 @@ class DiscordManager:
     def send_to_webhook(self, key: str, data: str, description: str, fields: dict = None, **kwargs):
         try:
             url = URLS.get_url(key)
+            if not url:
+                logger.debug("Webhook '%s' is not configured; notification skipped", key)
+                return None
             if data is None:
                 data = ""
 

--- a/src/orbit/core/execution.py
+++ b/src/orbit/core/execution.py
@@ -1,0 +1,59 @@
+"""Execution-environment configuration for Orbit.
+
+Trading environments are deliberately explicit.  The safe default is ``paper``;
+live order submission additionally requires a separate acknowledgement variable.
+"""
+
+from dataclasses import dataclass
+from enum import Enum
+import os
+
+
+class ExecutionMode(str, Enum):
+    PAPER = "paper"
+    TESTNET = "testnet"
+    LIVE = "live"
+
+
+FUTURES_TESTNET_URL = "https://demo-fapi.binance.com"
+
+
+@dataclass(frozen=True)
+class ExecutionSettings:
+    mode: ExecutionMode
+    api_key: str | None
+    secret_key: str | None
+    futures_base_url: str | None
+
+    @property
+    def can_submit_orders(self) -> bool:
+        return self.mode in (ExecutionMode.TESTNET, ExecutionMode.LIVE)
+
+    @classmethod
+    def from_env(cls) -> "ExecutionSettings":
+        raw_mode = os.getenv("ORBIT_EXECUTION_MODE", ExecutionMode.PAPER.value).lower()
+        try:
+            mode = ExecutionMode(raw_mode)
+        except ValueError as exc:
+            raise ValueError(
+                "ORBIT_EXECUTION_MODE must be one of: paper, testnet, live"
+            ) from exc
+
+        if mode is ExecutionMode.TESTNET:
+            api_key = os.getenv("BINANCE_TESTNET_API_KEY")
+            secret_key = os.getenv("BINANCE_TESTNET_SECRET_KEY")
+            base_url = os.getenv("BINANCE_FUTURES_TESTNET_URL", FUTURES_TESTNET_URL)
+        else:
+            # Keep the legacy misspelling as a temporary compatibility fallback.
+            api_key = os.getenv("BINANCE_API_KEY") or os.getenv("BINANE_API_KEY")
+            secret_key = os.getenv("BINANCE_SECRET_KEY") or os.getenv("SECRET_KEY")
+            base_url = None
+
+        if mode is ExecutionMode.LIVE and os.getenv("ORBIT_LIVE_TRADING_ACK") != "I_UNDERSTAND":
+            raise RuntimeError(
+                "Live trading is locked. Set ORBIT_LIVE_TRADING_ACK=I_UNDERSTAND explicitly."
+            )
+        if mode in (ExecutionMode.TESTNET, ExecutionMode.LIVE) and not (api_key and secret_key):
+            raise RuntimeError(f"Binance credentials are required in {mode.value} mode")
+
+        return cls(mode, api_key, secret_key, base_url)

--- a/src/orbit/core/main.py
+++ b/src/orbit/core/main.py
@@ -39,6 +39,8 @@ from orbit.core.trade_checker import TradeChecker
 from orbit.core.order_manager import OrderManager
 from orbit.core.exception_manager import ExceptionManager
 from orbit.core.sentimen_cron import Croner
+from orbit.core.performance_reporter import PerformanceReporter
+from orbit.core.execution import ExecutionMode
 from orbit.utils.utils import get_indian_time
 
 # Constants
@@ -222,6 +224,7 @@ class BinanceAutomation(ExceptionManager):
         stop_loss = signal["stop_loss"]
         target = signal["take_profit"]
         meta_info = signal.get("Other Info", "")
+        decision_id = signal.get("decision_id")
 
         if meta_info:
             self.send_logs(data=f"{symbol} - {action}", description=f"Signal Info: {meta_info}", fields=None)
@@ -239,15 +242,29 @@ class BinanceAutomation(ExceptionManager):
             stop_loss,
             target,
             leverage,
+            trade_id=decision_id,
         )
 
         time.sleep(0.5)
 
         if not order_response:
+            if decision_id and self.order_manager.mongo_handler is not None:
+                self.order_manager.mongo_handler.append_decision_event(
+                    decision_id, {"status": "order_rejected"}
+                )
             self.send_alerts(data=None, description=f"Order failed for {symbol}")
             return
 
         order_id = order_response.get("orderId")
+        if decision_id and self.order_manager.mongo_handler is not None:
+            self.order_manager.mongo_handler.append_decision_event(
+                decision_id,
+                {
+                    "status": "order_submitted",
+                    "order_id": order_id,
+                    "client_order_id": order_response.get("clientOrderId"),
+                },
+            )
         monitor_thread = threading.Thread(
             target=self.monitor_order_execution,
             args=(symbol, order_id, action, quantity, order_request["price"]),
@@ -364,6 +381,18 @@ class BinanceAutomation(ExceptionManager):
                 logger.info(f"Worker {worker.name} is alive.")
             time.sleep(check_interval)
 
+    def report_performance(self, interval_seconds: int = 86400) -> None:
+        """Sync Binance income and emit a fee-aware report once per day."""
+        reporter = PerformanceReporter(
+            self.order_manager.future_client, self.order_manager.mongo_handler
+        )
+        while True:
+            try:
+                reporter.report_last_24_hours()
+            except Exception as exc:
+                self.handle_exception(exc, "Exception in performance reporter")
+            time.sleep(interval_seconds)
+
     # ------------------------------------------------------------------
     # Main runner
     # ------------------------------------------------------------------
@@ -380,6 +409,15 @@ class BinanceAutomation(ExceptionManager):
         trade_thread = threading.Thread(target=self.start_trade_checker, daemon=True, name="TradeCheckerThread")
         trade_thread.start()
         self.workers_to_monitor.append(trade_thread)
+
+        if self.order_manager.execution_settings.mode is not ExecutionMode.PAPER:
+            performance_thread = threading.Thread(
+                target=self.report_performance,
+                daemon=True,
+                name="PerformanceReporterThread",
+            )
+            performance_thread.start()
+            self.workers_to_monitor.append(performance_thread)
 
         logger.info("All automation threads started successfully")
         self.start_signal_analysis()

--- a/src/orbit/core/mongo_handler.py
+++ b/src/orbit/core/mongo_handler.py
@@ -63,7 +63,7 @@ class MongoHandler(ExceptionManager):
 
     def __init__(
         self,
-        uri: str = "mongodb://localhost:27017",
+        uri: Optional[str] = None,
         db_name: str = "orbit",
         mongo_client: Any = None,
     ) -> None:
@@ -75,6 +75,7 @@ class MongoHandler(ExceptionManager):
             return
 
         try:
+            uri = uri or os.getenv("MONGODB_URI", "mongodb://localhost:27017")
             self._mongo_client = mongo_client or MongoClient(uri, serverSelectionTimeoutMS=1000)
             self.db = self._mongo_client[db_name]
             self.collection = self.db[OHLCV_COLLECTION_NAME]
@@ -88,6 +89,15 @@ class MongoHandler(ExceptionManager):
             self.simulated_trades_collection = self.db["simulated_trades"]
             self.simulated_trades_collection.create_index(
                 [("symbol", ASCENDING), ("trade_timestamp", ASCENDING)]
+            )
+            self.decision_collection = self.db["trade_decisions"]
+            self.decision_collection.create_index("decision_id", unique=True)
+            self.decision_collection.create_index(
+                [("symbol", ASCENDING), ("timestamp", ASCENDING)]
+            )
+            self.income_collection = self.db["futures_income"]
+            self.income_collection.create_index(
+                [("tranId", ASCENDING), ("incomeType", ASCENDING)], unique=True
             )
         except Exception as exc:
             logger.exception(f"Error initializing MongoDB: {exc}")
@@ -296,6 +306,68 @@ class MongoHandler(ExceptionManager):
     # ------------------------------------------------------------------
     # Data persistence
     # ------------------------------------------------------------------
+
+    def store_trade_decision(self, record: Dict[str, Any]) -> None:
+        """Persist an immutable strategy decision, including rejected signals."""
+        collection = getattr(self, "decision_collection", None)
+        if collection is None:
+            logger.warning("Mongo trade_decisions collection not available.")
+            return
+        try:
+            collection.update_one(
+                {"decision_id": record["decision_id"]},
+                {"$setOnInsert": record},
+                upsert=True,
+            )
+        except Exception as exc:
+            self.handle_exception(exc, "Error storing trade decision")
+
+    def append_decision_event(self, decision_id: str, event: Dict[str, Any]) -> None:
+        """Append an execution transition without rewriting the original decision."""
+        collection = getattr(self, "decision_collection", None)
+        if collection is None or not decision_id:
+            return
+        event = {"timestamp": datetime.now(timezone.utc), **event}
+        try:
+            collection.update_one(
+                {"decision_id": decision_id}, {"$push": {"execution_events": event}}
+            )
+        except Exception as exc:
+            self.handle_exception(exc, "Error appending trade decision event")
+
+    def store_income_records(self, records: List[Dict[str, Any]]) -> None:
+        """Upsert Binance income rows used for fee-aware return accounting."""
+        collection = getattr(self, "income_collection", None)
+        if collection is None:
+            logger.warning("Mongo futures_income collection not available.")
+            return
+        for record in records:
+            try:
+                identity = {
+                    "tranId": record.get("tranId"),
+                    "incomeType": record.get("incomeType"),
+                }
+                collection.update_one(identity, {"$setOnInsert": record}, upsert=True)
+            except Exception as exc:
+                self.handle_exception(exc, "Error storing futures income record")
+
+    def get_daily_net_pnl(self) -> float:
+        """Return today's net Futures income from the locally synced ledger."""
+        collection = getattr(self, "income_collection", None)
+        if collection is None:
+            return 0.0
+        start_ms = int(
+            datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0).timestamp()
+            * 1000
+        )
+        try:
+            return sum(
+                float(row.get("income", 0) or 0)
+                for row in collection.find({"time": {"$gte": start_ms}}, {"income": 1})
+            )
+        except Exception as exc:
+            self.handle_exception(exc, "Error calculating daily net PnL")
+            return 0.0
 
     def store_historical_data(self, symbol: str, df: pd.DataFrame, interval: str = "15m") -> None:
         """Persist OHLCV rows into MongoDB with a 60-day TTL.

--- a/src/orbit/core/order_manager.py
+++ b/src/orbit/core/order_manager.py
@@ -18,6 +18,7 @@ through the constructor for easier testing and looser coupling.
 import json
 import time
 import logging
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from binance.error import ClientError
@@ -27,6 +28,9 @@ from orbit.core.mongo_handler import MongoHandler
 from orbit.core.redis_manager import RedisManager
 from orbit.utils.utils import get_indian_time
 from orbit.core.plugins import get_swing_sl
+from orbit.core.execution import ExecutionMode
+from orbit.core.risk_manager import PreTradeRiskGuard
+from orbit.core.performance import PerformanceTracker
 
 logger = logging.getLogger("Orbit")
 
@@ -68,6 +72,7 @@ class OrderManager(AuthenticationManager, RedisManager):
     ) -> None:
         AuthenticationManager.__init__(self, **auth_kwargs)
         RedisManager.__init__(self, redis_client=redis_client)
+        self.risk_guard = PreTradeRiskGuard(self.config.get("risk_policy"))
 
         if mongo_handler is not None:
             self.mongo_handler: Optional[MongoHandler] = mongo_handler
@@ -177,6 +182,17 @@ class OrderManager(AuthenticationManager, RedisManager):
         """Return the total USDT wallet balance on the Futures account."""
         account_info = self.future_client.account()
         return float(account_info["totalWalletBalance"])
+
+    def get_daily_net_pnl(self) -> float:
+        """Synchronize today's exchange income before applying the loss halt."""
+        start_ms = int(
+            datetime.now(timezone.utc)
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+            .timestamp()
+            * 1000
+        )
+        tracker = PerformanceTracker(self.future_client, self.mongo_handler)
+        return tracker.sync(start_ms).net_pnl
 
     def fixed_asset_allocated(self, symbol: str, price: float) -> float:
         """Compute the coin quantity affordable from the fixed USDT allocation.
@@ -447,34 +463,21 @@ class OrderManager(AuthenticationManager, RedisManager):
         Returns:
             A ``(quantity, required_margin)`` tuple.
         """
-        qty = 0.002  # temporary fixed quantity for testing
-        qty = self.adjust_quantity_step(symbol, qty)
-        required_margin = (entry_price * qty) / leverage
-        return qty, required_margin
-
-        # -----------------------------
-        # 1. Fetch equity
-        # -----------------------------
-        equity = self.config['FIXED_TRADE_AMOUNT'].get(symbol, self.FIXED_SPEND_USDT)
-        risk_value = equity * risk_perc
-
-        if entry_price <= 0 or stop_price <= 0:
+        if entry_price <= 0 or stop_price is None or stop_price <= 0 or leverage <= 0:
             return 0.0, 0.0
-
-        if entry_price > stop_price:
-            stop_distance = entry_price - stop_price
-        else:
-            stop_distance = stop_price - entry_price
-
+        equity = self.get_usdt_balance()
+        effective_risk = min(float(risk_perc), self.risk_guard.max_risk_per_trade_pct)
+        risk_value = equity * effective_risk
+        stop_distance = abs(entry_price - stop_price)
         if stop_distance <= 0:
             return 0.0, 0.0
-
         qty_risk = risk_value / stop_distance
 
         filters = self.get_symbol_filters(symbol)
         min_notional_filter = filters.get("MIN_NOTIONAL")
         min_notional = float(min_notional_filter["notional"]) if min_notional_filter else 5.0
         min_qty = min_notional / entry_price
+        # Reject later if the exchange minimum itself would violate policy.
         qty = max(qty_risk, min_qty)
         qty = self.adjust_quantity_step(symbol, qty)
         required_margin = (entry_price * qty) / leverage
@@ -524,12 +527,21 @@ class OrderManager(AuthenticationManager, RedisManager):
                 )
                 return None, None, None
 
+            if self.execution_settings.mode is ExecutionMode.PAPER:
+                logger.warning("Order blocked: ORBIT_EXECUTION_MODE=paper")
+                self.send_alerts(
+                    data=None,
+                    description="Order blocked in paper mode",
+                    fields={"symbol": symbol, "side": side},
+                )
+                return None, None, None
+
             effective_trade_id = trade_id or symbol
 
             balance_available = self.get_usdt_balance()
             qty_from_alloc: float = 0.0
 
-            if symbol == 'BTCUSDT':
+            if sl is not None and symbol in risk_management:
                 qty_from_alloc, req_margin = self.calculate_risk_position_size(
                     symbol=symbol, entry_price=price, stop_price=sl,
                     risk_perc=risk_management[symbol], leverage=leverage
@@ -570,6 +582,29 @@ class OrderManager(AuthenticationManager, RedisManager):
                 logger.warning(f"[{symbol}] Quantity adjusted for stepSize: {quantity} -> {qty_valid}")
             quantity = qty_valid
 
+            if sl is None:
+                logger.error("Order rejected: a stop loss is required by risk policy")
+                return None, None, None
+
+            risk_decision = self.risk_guard.evaluate(
+                equity=balance_available,
+                entry_price=price,
+                stop_loss=float(sl),
+                take_profit=float(target) if target is not None else None,
+                quantity=quantity,
+                leverage=leverage,
+                side=side,
+                daily_net_pnl=self.get_daily_net_pnl(),
+            )
+            if not risk_decision.allowed:
+                logger.warning("Order rejected by risk guard: %s", risk_decision.reason)
+                self.send_alerts(
+                    data=None,
+                    description=f"Order rejected by risk guard: {risk_decision.reason}",
+                    fields={"symbol": symbol, **risk_decision.metrics},
+                )
+                return None, None, None
+
             if not self.validate_notional(symbol, price, quantity):
                 filters = self.get_symbol_filters(symbol)
                 min_notional = filters["MIN_NOTIONAL"]["notional"] if filters.get("MIN_NOTIONAL") else "N/A"
@@ -608,6 +643,10 @@ class OrderManager(AuthenticationManager, RedisManager):
                 "price": str(price),
                 "recvWindow": 60000,
             }
+            if trade_id:
+                # Binance client order IDs are capped at 36 characters.
+                compact_id = str(trade_id).replace("-", "")[:32]
+                params["newClientOrderId"] = f"o{compact_id}"
 
             order_response = self.future_client.new_order(**params)
             time.sleep(2)
@@ -676,6 +715,9 @@ class OrderManager(AuthenticationManager, RedisManager):
             The API response dict, or ``None`` on failure.
         """
         try:
+            if self.execution_settings.mode is ExecutionMode.PAPER:
+                logger.warning("Market order blocked: ORBIT_EXECUTION_MODE=paper")
+                return None
             current_price = self.get_symbol_price(symbol)
 
             if quantity is None:

--- a/src/orbit/core/performance.py
+++ b/src/orbit/core/performance.py
@@ -1,0 +1,71 @@
+"""Net-return accounting for Binance USD-M Futures income records."""
+
+from collections import defaultdict
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+
+@dataclass(frozen=True)
+class PerformanceSummary:
+    realized_pnl: float
+    commission: float
+    funding: float
+    other_income: float
+    net_pnl: float
+    return_pct: float | None
+    records: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class PerformanceTracker:
+    """Normalise and aggregate the exchange's immutable income ledger."""
+
+    def __init__(self, futures_client: Any, mongo_handler: Any = None) -> None:
+        self.futures_client = futures_client
+        self.mongo_handler = mongo_handler
+
+    @staticmethod
+    def summarize(records: Iterable[dict[str, Any]], starting_equity: float | None = None) -> PerformanceSummary:
+        totals: defaultdict[str, float] = defaultdict(float)
+        count = 0
+        for record in records:
+            count += 1
+            income = float(record.get("income", 0) or 0)
+            income_type = str(record.get("incomeType", "OTHER")).upper()
+            if income_type == "REALIZED_PNL":
+                totals["realized"] += income
+            elif income_type == "COMMISSION":
+                totals["commission"] += income
+            elif income_type == "FUNDING_FEE":
+                totals["funding"] += income
+            else:
+                totals["other"] += income
+        net = sum(totals.values())
+        return_pct = None
+        if starting_equity and starting_equity > 0:
+            return_pct = (net / starting_equity) * 100
+        return PerformanceSummary(
+            realized_pnl=totals["realized"],
+            commission=totals["commission"],
+            funding=totals["funding"],
+            other_income=totals["other"],
+            net_pnl=net,
+            return_pct=return_pct,
+            records=count,
+        )
+
+    def sync(self, start_time_ms: int | None = None) -> PerformanceSummary:
+        params = {"recvWindow": 60000}
+        if start_time_ms is not None:
+            params["startTime"] = start_time_ms
+        records = self.futures_client.get_income_history(**params)
+        if self.mongo_handler is not None:
+            self.mongo_handler.store_income_records(records)
+        return self.summarize(records)
+
+    @staticmethod
+    def utc_now() -> datetime:
+        return datetime.now(timezone.utc)

--- a/src/orbit/core/performance_reporter.py
+++ b/src/orbit/core/performance_reporter.py
@@ -1,0 +1,41 @@
+"""Periodic fee-aware performance reporting."""
+
+from datetime import datetime, timedelta, timezone
+import logging
+from typing import Any
+
+from orbit.core.discord_manager import DiscordManager
+from orbit.core.performance import PerformanceTracker
+
+logger = logging.getLogger("Orbit")
+
+
+class PerformanceReporter(DiscordManager):
+    def __init__(self, futures_client: Any, mongo_handler: Any = None) -> None:
+        super().__init__()
+        self.client = futures_client
+        self.tracker = PerformanceTracker(futures_client, mongo_handler)
+
+    def report_last_24_hours(self) -> dict[str, Any]:
+        start = datetime.now(timezone.utc) - timedelta(hours=24)
+        records = self.client.get_income_history(
+            startTime=int(start.timestamp() * 1000), recvWindow=60000
+        )
+        if self.tracker.mongo_handler is not None:
+            self.tracker.mongo_handler.store_income_records(records)
+        wallet = float(self.client.account()["totalWalletBalance"])
+        summary = self.tracker.summarize(records)
+        starting_equity = wallet - summary.net_pnl
+        summary = self.tracker.summarize(records, starting_equity=starting_equity)
+        payload = {
+            "window": "24h",
+            "wallet_equity": wallet,
+            **summary.to_dict(),
+        }
+        logger.info("24h performance: %s", payload)
+        self.send_logs(
+            data=None,
+            description="Orbit Futures performance (last 24h)",
+            fields=payload,
+        )
+        return payload

--- a/src/orbit/core/redis_manager.py
+++ b/src/orbit/core/redis_manager.py
@@ -30,6 +30,7 @@ Key schema
 
 import json
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Iterator, Optional
 
@@ -92,7 +93,10 @@ class RedisManager:
         redis_client: Optional[redis.StrictRedis] = None,
     ) -> None:
         self.redis_client: redis.StrictRedis = redis_client or redis.StrictRedis(
-            host="localhost", port=6379, db=0, decode_responses=True
+            host=os.getenv("REDIS_HOST", "localhost"),
+            port=int(os.getenv("REDIS_PORT", "6379")),
+            db=int(os.getenv("REDIS_DB", "0")),
+            decode_responses=True,
         )
 
     # ------------------------------------------------------------------

--- a/src/orbit/core/risk_manager.py
+++ b/src/orbit/core/risk_manager.py
@@ -1,0 +1,81 @@
+"""Deterministic pre-trade risk controls.
+
+These checks are intentionally independent from strategy code.  A strategy may
+propose a trade; it cannot bypass portfolio safety policy.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+
+@dataclass(frozen=True)
+class RiskDecision:
+    allowed: bool
+    reason: str
+    metrics: dict[str, float]
+
+
+class PreTradeRiskGuard:
+    def __init__(self, policy: Mapping[str, Any] | None = None) -> None:
+        policy = policy or {}
+        self.max_leverage = int(policy.get("max_leverage", 5))
+        self.max_position_notional_pct = float(
+            policy.get("max_position_notional_pct", 0.25)
+        )
+        self.max_risk_per_trade_pct = float(policy.get("max_risk_per_trade_pct", 0.01))
+        self.min_reward_risk_ratio = float(policy.get("min_reward_risk_ratio", 1.5))
+        self.max_daily_loss_pct = float(policy.get("max_daily_loss_pct", 0.02))
+
+    def evaluate(
+        self,
+        *,
+        equity: float,
+        entry_price: float,
+        stop_loss: float,
+        take_profit: float | None,
+        quantity: float,
+        leverage: int,
+        side: str,
+        daily_net_pnl: float = 0.0,
+    ) -> RiskDecision:
+        if min(equity, entry_price, stop_loss, quantity) <= 0:
+            return RiskDecision(False, "non_positive_input", {})
+        if leverage < 1 or leverage > self.max_leverage:
+            return RiskDecision(False, "leverage_limit", {"leverage": float(leverage)})
+        side = side.upper()
+        if side not in ("BUY", "SELL"):
+            return RiskDecision(False, "invalid_side", {})
+        if (side == "BUY" and stop_loss >= entry_price) or (
+            side == "SELL" and stop_loss <= entry_price
+        ):
+            return RiskDecision(False, "stop_on_wrong_side", {})
+        if take_profit is not None and (
+            (side == "BUY" and take_profit <= entry_price)
+            or (side == "SELL" and take_profit >= entry_price)
+        ):
+            return RiskDecision(False, "target_on_wrong_side", {})
+        if daily_net_pnl <= -(equity * self.max_daily_loss_pct):
+            return RiskDecision(
+                False, "daily_loss_limit", {"daily_net_pnl": daily_net_pnl}
+            )
+
+        stop_distance = abs(entry_price - stop_loss)
+        risk_usdt = stop_distance * quantity
+        risk_pct = risk_usdt / equity
+        notional_pct = (entry_price * quantity) / equity
+        metrics = {
+            "risk_usdt": risk_usdt,
+            "risk_pct": risk_pct,
+            "notional_pct": notional_pct,
+        }
+        if risk_pct > self.max_risk_per_trade_pct:
+            return RiskDecision(False, "risk_per_trade_limit", metrics)
+        if notional_pct > self.max_position_notional_pct:
+            return RiskDecision(False, "position_notional_limit", metrics)
+
+        if take_profit is not None:
+            reward_risk = abs(take_profit - entry_price) / stop_distance
+            metrics["reward_risk_ratio"] = reward_risk
+            if reward_risk < self.min_reward_risk_ratio:
+                return RiskDecision(False, "reward_risk_below_minimum", metrics)
+        return RiskDecision(True, "allowed", metrics)

--- a/src/orbit/core/signal_analyzer.py
+++ b/src/orbit/core/signal_analyzer.py
@@ -12,6 +12,8 @@ the constructor for easier testing and looser coupling.
 
 import time
 import logging
+import uuid
+from importlib import metadata
 from typing import Any, Dict, Iterator, List, Optional
 
 import redis
@@ -63,6 +65,31 @@ class SignalAnalyzer(AuthenticationManager, RedisManager):
 
         self.contradict_simulator = ContradictSimulator(mongo_handler=self.mongo_handler)
 
+    @staticmethod
+    def _strategy_identity(strategy_class: type) -> Dict[str, str]:
+        try:
+            package_version = metadata.version("orbit-strategies")
+        except metadata.PackageNotFoundError:
+            package_version = "development"
+        return {
+            "strategy": f"{strategy_class.__module__}.{strategy_class.__name__}",
+            "strategy_version": package_version,
+        }
+
+    def _record_decision(self, **values: Any) -> str:
+        decision_id = str(values.pop("decision_id", uuid.uuid4()))
+        record = {
+            "decision_id": decision_id,
+            "timestamp": get_indian_time(),
+            "execution_mode": self.execution_settings.mode.value,
+            **values,
+        }
+        if getattr(self, "mongo_handler", None) is not None:
+            self.mongo_handler.store_trade_decision(record)
+        else:
+            logger.warning("Trade decision %s was not persisted: MongoDB unavailable", decision_id)
+        return decision_id
+
     def analyze_market(self, cooldown_symbols: List[str]) -> Iterator[Dict[str, Any]]:
         """Iterate over trading pairs and yield actionable signal dicts.
 
@@ -80,12 +107,18 @@ class SignalAnalyzer(AuthenticationManager, RedisManager):
                 historical_data = self.mongo_handler.handle_mongo_data(symbol)
                 if historical_data.empty:
                     self.send_alerts(f"No historical data found for {symbol}", None)
+                    self._record_decision(
+                        symbol=symbol, outcome="rejected", reason="historical_data_unavailable"
+                    )
                     continue
 
                 strategy_class = STRATEGY_REGISTRY.get(symbol)
                 if not strategy_class:
                     self.send_alerts(f"No strategy found for {symbol}", None)
+                    self._record_decision(symbol=symbol, outcome="rejected", reason="strategy_not_found")
                     continue
+
+                strategy_identity = self._strategy_identity(strategy_class)
 
                 try:
                     strategy = strategy_class(historical_data)
@@ -94,27 +127,51 @@ class SignalAnalyzer(AuthenticationManager, RedisManager):
                     signal_es = time.perf_counter()
                 except Exception as e:
                     self.handle_exception(e, f"Exception while generating signals for {symbol}")
+                    self._record_decision(
+                        symbol=symbol, outcome="error", reason="strategy_exception",
+                        **strategy_identity,
+                    )
                     continue
 
                 if symbol in cooldown_symbols:
                     self.send_cooldown_update(data=None, description=f"{symbol} is in cooldown", fields=None)
+                    self._record_decision(
+                        symbol=symbol, outcome="rejected", reason="cooldown",
+                        **strategy_identity,
+                    )
                     continue
 
                 if not signal_dict:
                     self.send_signal_updates(data=None, description=f"{symbol}: No Signal Found", fields=None)
+                    self._record_decision(
+                        symbol=symbol, outcome="no_signal", reason="strategy_no_signal",
+                        **strategy_identity,
+                    )
                     time.sleep(0.5)
                     continue
 
                 signal = signal_dict.get("signal")
                 chart_path = signal_dict.get("chart_path")
                 chart_path_raw = signal_dict.get("chart_path_raw")
-                pattern = signal_dict.get("pattern")
+                pattern = signal_dict.get("pattern") or "unknown"
 
                 if 'breakout' in pattern.lower():
                     self.send_alerts(data=f"{symbol}", description=f"Pattern identified as Breakout: {pattern}", fields=None)
+                    self._record_decision(
+                        symbol=symbol, signal=signal, pattern=pattern,
+                        outcome="rejected", reason="breakout_filter", **strategy_identity,
+                    )
                     continue
 
-                if self._should_skip_due_to_sentiment(signal, symbol, signal_dict):
+                sentiment = self.get_market_sentiment()
+                if self._should_skip_due_to_sentiment(signal, symbol, signal_dict, sentiment=sentiment):
+                    self._record_decision(
+                        symbol=symbol, signal=signal, pattern=pattern, sentiment=sentiment,
+                        entry_price=signal_dict.get("entry_price"),
+                        stop_loss=signal_dict.get("stop_loss"),
+                        take_profit=signal_dict.get("take_profit"),
+                        outcome="rejected", reason="sentiment_conflict", **strategy_identity,
+                    )
                     continue
 
                 try:
@@ -123,18 +180,29 @@ class SignalAnalyzer(AuthenticationManager, RedisManager):
                     if chart_path_raw:
                         self.send_chart_to_webhook(file_path=chart_path_raw, data=None, description=f"{symbol}, signal = {signal}", fields=options)
 
+                    decision_id = self._record_decision(
+                        symbol=symbol, signal=signal, pattern=pattern, sentiment=sentiment,
+                        entry_price=signal_dict.get("entry_price"),
+                        stop_loss=signal_dict.get("stop_loss"),
+                        take_profit=signal_dict.get("take_profit"),
+                        outcome="accepted", reason="passed_filters", **strategy_identity,
+                    )
                     signal = {
+                        "decision_id": decision_id,
                         "symbol": symbol,
                         "signal": signal,
                         "timestamp": get_indian_time(),
                         "entry_price": signal_dict.get("entry_price"),
                         "stop_loss": signal_dict.get("stop_loss"),
                         "take_profit": signal_dict.get("take_profit"),
+                        "pattern": pattern,
+                        "sentiment": sentiment,
+                        **strategy_identity,
                         "Other Info": f"Time execution for signal Analysis = {signal_es - signal_ss:.4f} seconds",
                     }
                     yield signal
                 except Exception as e:
-                    self.handle_exception(e, f"Exception at inference, SIGNAL = {signal[0]} for {symbol}")
+                    self.handle_exception(e, f"Exception preparing signal for {symbol}")
 
                 time.sleep(0.5)
 
@@ -142,7 +210,7 @@ class SignalAnalyzer(AuthenticationManager, RedisManager):
             self.handle_exception(e, "Exception in analyze_market")
 
     def _should_skip_due_to_sentiment(
-        self, signal: str, symbol: str, trade_info: Dict[str, Any]
+        self, signal: str, symbol: str, trade_info: Dict[str, Any], sentiment: Optional[str] = None
     ) -> bool:
         """Check Redis for market sentiment and decide whether to skip.
 
@@ -154,7 +222,7 @@ class SignalAnalyzer(AuthenticationManager, RedisManager):
             ``True`` if the signal should be discarded.
         """
         try:
-            sentiment = self.get_market_sentiment()
+            sentiment = sentiment if sentiment is not None else self.get_market_sentiment()
             if sentiment:
                 skip = False
 

--- a/src/orbit/core/signal_analyzer.py
+++ b/src/orbit/core/signal_analyzer.py
@@ -68,7 +68,7 @@ class SignalAnalyzer(AuthenticationManager, RedisManager):
     @staticmethod
     def _strategy_identity(strategy_class: type) -> Dict[str, str]:
         try:
-            package_version = metadata.version("orbit-strategies")
+            package_version = metadata.version("orbit")
         except metadata.PackageNotFoundError:
             package_version = "development"
         return {

--- a/src/orbit/strategies/agglo_strategy.py
+++ b/src/orbit/strategies/agglo_strategy.py
@@ -1,0 +1,1023 @@
+import os
+import sys
+import time
+import redis
+import json
+import numpy as np
+import pandas as pd
+import logging
+from abc import abstractmethod
+from typing import Dict, List, Tuple, Any
+from sklearn.cluster import AgglomerativeClustering
+from sklearn.preprocessing import StandardScaler
+from sklearn.metrics import silhouette_score
+from orbit.strategies.strategies_base import Strategy
+from orbit.utils.utils import generate_chart
+
+
+# Color codes for terminal output
+class Colors:
+    RED = '\033[91m'
+    GREEN = '\033[92m'
+    YELLOW = '\033[93m'
+    BLUE = '\033[94m'
+    PURPLE = '\033[95m'
+    CYAN = '\033[96m'
+    WHITE = '\033[97m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+    END = '\033[0m'
+    MAGENTA = "\033[35m"
+
+# Custom colored logger
+class ColoredLogger:
+    def __init__(self, logger):
+        self.logger = logger
+    
+    def info(self, message, color=Colors.WHITE):
+        self.logger.info(f"{color}{message}{Colors.END}")
+
+    def info_c(self, message, color=Colors.WHITE):
+        self.logger.info(f"{color}{message}{Colors.END}")
+    
+    def debug(self, message, color=Colors.CYAN):
+        self.logger.debug(f"{color}{message}{Colors.END}")
+    
+    def warning(self, message, color=Colors.YELLOW):
+        self.logger.warning(f"{color}{message}{Colors.END}")
+    
+    def error(self, message, color=Colors.RED):
+        self.logger.error(f"{color}{message}{Colors.END}")
+
+    def ohlc(self, message, color=Colors.CYAN):
+        self.logger.info(f"{color}{message}{Colors.END}")     
+    
+    def success(self, message):
+        self.logger.debug(f"{Colors.GREEN}{Colors.BOLD}{message}{Colors.END}")
+    
+    def cluster(self, message):
+        self.logger.debug(f"{Colors.PURPLE}{Colors.BOLD}{message}{Colors.END}")
+    
+    def resistance(self, message):
+        self.logger.debug(f"{Colors.RED}{Colors.BOLD}{message}{Colors.END}")
+    
+    def support(self, message):
+        self.logger.debug(f"{Colors.GREEN}{Colors.BOLD}{message}{Colors.END}")
+    
+    def params(self, message):
+        self.logger.debug(f"{Colors.BLUE}{Colors.BOLD}{message}{Colors.END}")
+    
+    def filter_pass(self, message):
+        self.logger.debug(f"{Colors.GREEN}{message}{Colors.END}")
+    
+    def filter_fail(self, message):
+        self.logger.debug(f"{Colors.RED}{message}{Colors.END}")
+    
+    def sweep(self, message):
+        self.logger.debug(f"{Colors.PURPLE}{Colors.BOLD}🔧 SWEEP: {message}{Colors.END}")
+    
+    def fibonacci(self, message):
+        self.logger.debug(f"{Colors.CYAN}{Colors.BOLD}🔢 FIBONACCI: {message}{Colors.END}")
+    
+    def seperator(self, message = None ):
+        """Logs a separator line with an optional title."""
+        length = 60 
+        character = "="
+        if message:
+            line = f" {message} ".center(60, character)
+        else:
+            line = character * length
+        logger.info(line)
+
+# Change to DEBUG for detailed logs
+base_logger = logging.getLogger("Orbit")
+logger = ColoredLogger(base_logger)
+
+
+class AggloBase(Strategy):
+    def __init__(self, data: pd.DataFrame):
+        super().__init__(data)
+        self.redis_client = None
+    
+        try:
+            self.redis_client = redis.StrictRedis(
+                host=os.getenv("REDIS_HOST", "localhost"),
+                port=int(os.getenv("REDIS_PORT", "6379")),
+                db=int(os.getenv("REDIS_DB", "0")),
+                decode_responses=True,
+            )
+        except Exception as e:
+            logger.error(f"Redis connection error: {e}")
+            self.redis_client = None
+
+    class PersistencePlugin:
+        """Maintain and update SR levels across lookbacks."""
+        def __init__(self, redis_client, **kwargs):
+            self.redis_client = redis_client
+            class_name = kwargs.get('class_name', None)
+            logger.info(f"Class name = {class_name.split('_')}")
+            self.COIN = class_name.split('_')[-1]
+            try:
+                data = self.redis_client.get(f"{self.COIN}_support_level")
+                data = {float(k): v for k, v in json.loads(data).items()}
+                self.support_levels: dict[float, float] = data if data else {}
+                logger.info(f"Loaded support levels from Redis for {self.COIN}: {self.support_levels}")
+            except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+                logger.error("⚠️ Redis is not accessible. Using empty support_levels.")
+                self.support_levels = {}
+            except Exception as e:
+                logger.error(f"Error loading support levels from Redis: {e}")
+                self.support_levels = {}
+
+            try:
+                data = self.redis_client.get(f"{self.COIN}_resistance_level")
+                data = {float(k): v for k, v in json.loads(data).items()}
+                self.resistance_levels: dict[float, float] = data if data else {}
+                logger.info(f"Loaded resistance levels from Redis for {self.COIN}: {self.resistance_levels}")
+            except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+                logger.error("⚠️ Redis is not accessible. Using empty resistance_levels.")
+                self.resistance_levels = {}
+            except Exception as e:
+                logger.error(f"Error loading resistance levels from Redis: {e}")
+                self.resistance_levels = {}
+
+            self.breaked_support_level: List[float] = []  #
+            self.breaked_resistance_level: List[float] = []  #
+            self.inactive_bars = 10000  # Bars to consider a level inactive
+            self.history = []  # list of (call_index, {level: score})
+            self.call_index = 0
+
+        def get_support_levels(self) -> List[float]:
+            return sorted(list(self.support_levels.keys()), reverse=True)
+        
+        def get_resistance_levels(self) -> List[float]:
+            return sorted(list(self.resistance_levels.keys()))
+
+        def update(self, df: pd.DataFrame, **kwargs) -> List[float]:
+
+            window_end = kwargs.get('window_end')
+            close_price = df['close'].iloc[-1]
+
+            if 'support_zones' in kwargs:
+                for level in kwargs['support_zones']:
+                    if level not in self.get_support_levels() and level < close_price:
+                        self.support_levels[level] = window_end
+
+            s_levels = self.get_support_levels()
+            logger.info(f"Current Support Levels before update: {s_levels}")
+            for level in s_levels:
+                level_idx = self.support_levels[level]
+                if df.iloc[level_idx:window_end]['close'].min() < level or  level > close_price:
+                    self.breaked_support_level.append(level)
+                    del self.support_levels[level]
+                    logger.info(f"Support level {level} broken at index {window_end}")
+                
+                if window_end > level_idx + self.inactive_bars:  # 1000 bars cooldown
+                    del self.support_levels[level]
+                    logger.info(f"Support level {level} removed due to inactivity at index {window_end}")
+
+                
+            if 'resistance_zones' in kwargs:
+                for level in kwargs['resistance_zones']:
+                    if level not in self.get_resistance_levels() and level > close_price:
+                        self.resistance_levels[level] = window_end                  
+
+            r_levels = self.get_resistance_levels()
+            logger.info(f"Current Resistance Levels before update: {r_levels}")
+            for level in r_levels:
+                level_idx = self.resistance_levels[level]
+
+                if df.iloc[level_idx:window_end]['close'].max() > level or level <= close_price:
+                    self.breaked_resistance_level.append(level)
+                    del self.resistance_levels[level]
+                    logger.info(f"Resistance level {level} broken at index {window_end}")
+
+                if window_end > level_idx + self.inactive_bars:  # 1000 bars cooldown
+                    del self.resistance_levels[level]
+                    logger.info(f"Resistance level {level} removed due to inactivity at index {window_end}")
+
+            try:
+                self.redis_client.set(f"{self.COIN}_support_level", json.dumps(self.support_levels)) if 'support_zones' in kwargs else self.redis_client.set(f"{self.COIN}_resistance_level", json.dumps(self.resistance_levels))
+                logger.info(f"Persisted levels to Redis for {self.COIN}")
+            except (redis.exceptions.ConnectionError, redis.exceptions.TimeoutError):
+                logger.error("⚠️ Redis is not accessible. Changes to levels won't be persisted.")
+            return self.get_support_levels() if 'support_zones' in kwargs else self.get_resistance_levels()
+
+    # Parameter configuration class
+    class ParameterConfig:
+        """Configuration class for all tunable parameters"""
+        
+        def __init__(self, **kwargs):
+            # Default parameters for agglomerative clustering - LOOSENED for more detection
+            self.agglo_n_clusters_range = kwargs.get('agglo_n_clusters_range', (2, 10))  # Range for silhouette optimization
+            self.agglo_linkage = kwargs.get('agglo_linkage', 'average')  # 'ward', 'complete', 'average', 'single'
+            self.agglo_distance_threshold = kwargs.get('agglo_distance_threshold', None)  # For distance-based clustering
+            self.min_cluster_strength = kwargs.get('min_cluster_strength', 0.5)  # Reduced from 2.0 for more zones
+            self.volume_filter_threshold = kwargs.get('volume_filter_threshold', 1.0)  # Reduced from 1.5 for more volume points
+            self.wick_threshold = kwargs.get('wick_threshold', 0.4)  # Reduced from 0.75 for more wick detection
+            self.lookback_period = kwargs.get('lookback_period', 250)  # Increased from 50 for more data
+            self.step_size = kwargs.get('step_size', 30)
+            self.min_data_points = kwargs.get('min_data_points', 250)
+            self.rejection_atr_mul = kwargs.get('rejection_atr_mul', 2.5)  # ATR multiplier for rejection filtering
+            self.volume_ma = kwargs.get('volume_ma', 14)  # Moving average period for volume filtering
+            self.momentum_drop = kwargs.get('momentum_drop', 4)  # Minimum momentum drop to consider rejection
+            # LOOSENED PARAMETERS for more detection
+            self.recency_weight = kwargs.get('recency_weight', 0.5)  # Reduced from 0.7 for more balanced detection
+            self.max_zones_per_type = kwargs.get('max_zones_per_type', 5)  # Increased from 3 for more zones
+            self.price_relevance_threshold = kwargs.get('price_relevance_threshold', 0.25)  # Increased from 0.15 for more levels
+            self.min_touches_per_zone = kwargs.get('min_touches_per_zone', 2)  # Reduced from 2 for more zones
+            
+            # DBSCAN parameters for noise filtering
+            self.dbscan_eps_ratio = kwargs.get('dbscan_eps_ratio', 0.02)  # 2% of average price for epsilon
+            self.dbscan_min_samples = kwargs.get('dbscan_min_samples', 2)  # Minimum samples for core point
+            self.enable_dbscan_filtering = kwargs.get('enable_dbscan_filtering', True)  # Enable/disable DBSCAN filtering
+            
+            # Fibonacci parameters
+            self.fibonacci_levels = kwargs.get('fibonacci_levels', [0.5, 0.618, 1])
+
+            # Evalution parameters
+            self.evalution_atr_period = kwargs.get('evalution_atr_period', 14)  # ATR period for evaluation
+            self.evalution_lookahead = kwargs.get('evalution_lookahead', 25)  # Lookahead period for evaluation
+            self.evalution_breakout_penalty = kwargs.get('evalution_breakout_penalty', 0.5)  # Penalty for breakouts
+            self.persistence_decay = kwargs.get('persistence_decay', 0.9)  # Decay factor for persistence
+            self.evalution_tolerance_factor = kwargs.get('evalution_tolerance_factor', 0.5)  # ATR multiplier for tolerance
+            self.significant_move = kwargs.get('significant_move', 1.2)  # Minimum move size to consider significant
+            self.swing_lookback = kwargs.get('swing_lookback', 30)  # Lookback for swing high/low detection
+            self.swing_window = kwargs.get('swing_window', 5)  # Window size for swing detection
+            
+        def to_dict(self):
+            """Convert parameters to dictionary for wandb logging"""
+            return {
+                'agglo_n_clusters_range': self.agglo_n_clusters_range,
+                'agglo_linkage': self.agglo_linkage,
+                'agglo_distance_threshold': self.agglo_distance_threshold,
+                'min_cluster_strength': self.min_cluster_strength,
+                'volume_filter_threshold': self.volume_filter_threshold,
+                'wick_threshold': self.wick_threshold,
+                'lookback_period': self.lookback_period,
+                'step_size': self.step_size,
+                'min_data_points': self.min_data_points,
+                'recency_weight': self.recency_weight,
+                'max_zones_per_type': self.max_zones_per_type,
+                'price_relevance_threshold': self.price_relevance_threshold,
+                'min_touches_per_zone': self.min_touches_per_zone,
+                'dbscan_eps_ratio': self.dbscan_eps_ratio,
+                'dbscan_min_samples': self.dbscan_min_samples,
+                'enable_dbscan_filtering': self.enable_dbscan_filtering,
+                'fibonacci_levels': self.fibonacci_levels,
+                'volume_ma': self.volume_ma,
+                'evalution_atr_period': self.evalution_atr_period,
+                'evalution_lookahead': self.evalution_lookahead,
+                'evalution_breakout_penalty': self.evalution_breakout_penalty,
+                'persistence_decay': self.persistence_decay,
+                'evalution_tolerance_factor': self.evalution_tolerance_factor,
+                'significant_move': self.significant_move,
+                'rejection_atr_mul': self.rejection_atr_mul,
+                'swing_lookback': self.swing_lookback,
+                'swing_window': self.swing_window,
+                'momentum_drop': self.momentum_drop,
+            }
+        
+        def log_params(self):
+            """Log current parameters"""
+            logger.params("🔧 Current Parameters:")
+            for key, value in self.to_dict().items():
+                logger.params(f"   - {key}: {value}")
+
+
+
+    def find_swing_low(self, df:pd.DataFrame, window=3):
+        """
+        Identifies swing lows in OHLCV DataFrame.
+        A swing low is defined as a low lower than its 'window' neighbors on both sides.
+
+        Parameters:
+        - df: DataFrame with a 'Low' column.
+        - window: How many bars to look before and after for comparison.
+
+        Returns:
+        - Series of booleans (True where swing low occurs).
+        """
+        lows = df['low']
+        swing_lows = lows.rolling(window=window*2+1, center=True).apply(
+            lambda x: x[window] == min(x), raw=True
+        ) == 1
+        
+        if swing_lows.any():
+            # Return the value of the last swing low
+            last_index = swing_lows[swing_lows].index[-1]
+            return df.loc[last_index, 'low']
+        # No swing low found, return lowest low
+        return lows.min()
+    
+    def find_swing_high(self, df:pd.DataFrame, window:int=3) -> pd.Series:
+        """
+        Identifies swing highs in OHLCV DataFrame.
+        A swing high is defined as a high higher than its 'window' neighbors on both sides.
+
+        Parameters:
+        - df: DataFrame with a 'High' column.
+        - window: How many bars to look before and after for comparison.
+
+        Returns:
+        - Series of booleans (True where swing high occurs).
+        """
+        highs = df['high']
+        swing_highs = highs.rolling(window=window*2+1, center=True).apply(
+            lambda x: x[window] == max(x), raw=True
+        ) == 1
+        
+        if swing_highs.any():
+            # Return the value of the last swing high
+            last_index = swing_highs[swing_highs].index[-1]
+            return df.loc[last_index, 'high']
+        # No swing high found, return highest high
+        return highs.max()
+    
+    def SR_levls_implementation(self, df: pd.DataFrame, persistence: PersistencePlugin, params: ParameterConfig, window_end: int) -> Dict[str, List[float]]:
+
+        current_data = df.iloc[window_end-params.lookback_period:window_end].copy()
+        rejection_points, rejection_types, rejection_volumes = self.extract_price_rejection_points_momentum(
+            current_data,
+            params,
+        )
+
+        logger.debug(f"Rejection points extracted: {len(rejection_points)}")
+
+        # Analyze clusters with agglomerative clustering
+        results = self.analyze_clusters_agglomerative(
+            rejection_points, rejection_types, rejection_volumes, current_data, params, #support_levels=iterate_and_analyze_sr_levels.persistence.get_support_levels(), resistance_levels=iterate_and_analyze_sr_levels.persistence.get_resistance_levels()
+        )
+        logger.debug(f"Support and resistance zones identified with rejection points: {len(rejection_points)}")
+
+        resistance_zones = results.get('resistance_zones', [])
+        support_zones = results.get('support_zones', [])
+
+
+        support_levels = persistence.update(df=df, window_end=window_end, support_zones=support_zones)
+        logger.info(f"Support Levels: {support_levels}")
+        support_levels = support_levels[:50] # truncated for discord limit
+        resistance_levels = persistence.update(df=df, window_end=window_end, resistance_zones=resistance_zones)
+        logger.info(f"Resistance Levels: {resistance_levels}")
+        resistance_levels = resistance_levels[:50] # truncated for discord limit
+        return {'support': support_levels, 'resistance': resistance_levels}
+    
+    def extract_price_rejection_points_momentum(self, df: pd.DataFrame, params) -> Tuple[List[float], List[str], List[float]]:
+        """
+        Extract rejection points based on wick size, momentum-based rejection, and optionally pivot points.
+        Includes ATR and volume filters.
+        """
+        recent_data = df
+
+        rejection_points, rejection_types, rejection_volumes = [], [], []
+
+        highs, lows = recent_data['high'].values, recent_data['low'].values
+        opens, closes = recent_data['open'].values, recent_data['close'].values
+        volumes = recent_data['volume'].values
+
+        
+        # ATR (True Range)
+        tr = pd.concat([
+            df['high'] - df['low'],
+            (df['high'] - df['close'].shift()).abs(),
+            (df['low'] - df['close'].shift()).abs()
+        ], axis=1).max(axis=1)
+        atr = tr.rolling(14).mean().values
+
+        # avg_volume = recent_data['volume'].rolling(20).mean().values
+        # vol_std = recent_data['volume'].rolling(20).std(ddof=0).replace(0, np.nan)
+        # vol_zscore = ((recent_data['volume'] - avg_volume) / vol_std).values
+
+        momentum_drop = params.momentum_drop
+
+        range_window = 6
+        range_tolerance = 0.3
+        breakout_confirm = 2
+
+        # Calculate swing high and swing low
+        swing_high = max(highs)
+        swing_low = min(lows)
+        current_price = closes[-1]
+        if swing_high > current_price and (abs(swing_high - current_price) / current_price ) * 100 >= params.momentum_drop:
+            rejection_points.append(swing_high)
+            rejection_types.append("pivot_high")
+            rejection_volumes.append(volumes[np.argmax(recent_data['high'].values)])
+        if swing_low < current_price and (abs(current_price - swing_low) / current_price ) * 100 >= params.momentum_drop:
+            rejection_points.append(swing_low)
+            rejection_types.append("pivot_low")
+            rejection_volumes.append(volumes[np.argmin(recent_data['low'].values)])
+
+
+        for i in range(14, len(recent_data) - 6):
+            if np.isnan(atr[i]) or atr[i] <= 0:
+                continue
+
+            # ========== RESISTANCE ==========
+            # Case 1: Peak -> Drop
+            if highs[i] == max(highs[i-3:i+3]):  # local peak
+                segment = lows[i+1:]
+                if len(segment) == 0:
+                    continue
+                lowest_after_peak = min(segment)
+                drop = ((highs[i] - lowest_after_peak) / highs[i] ) * 100
+                if segment.size > 0 and drop >= momentum_drop:
+                    lowest_index_after_peak = i + 1 + np.argmin(segment)
+                    future_closes = closes[i:]
+                    if not np.any(future_closes > highs[i]):
+                        rejection_points.append(highs[i])
+                        rejection_types.append("momentum_drop")
+                        rejection_volumes.append(volumes[i])
+                        i = lowest_index_after_peak  # Skip ahead to avoid double counting
+
+            # Case 2: Peak + Range -> Drop
+            if i >= 3 and i < len(highs) - 3 and  highs[i] == max(highs[i-3:i+3]):  # local peak
+                range_high = np.max(highs[i+1:i+1+range_window])
+                range_low  = np.min(lows[i+1:i+1+range_window])
+                if (range_high - range_low) < atr[i] * range_tolerance:
+                    # drop check after consolidation
+                    if np.any(closes[i+range_window:i+range_window+breakout_confirm] < range_low):
+                        future_closes = closes[i:]
+                        if not np.any(future_closes > highs[i]):
+                            rejection_points.append(highs[i])
+                            rejection_types.append("momentum_drop")
+                            rejection_volumes.append(volumes[i])
+
+            # ========== SUPPORT ==========
+            # Case 1: Trough -> Rise
+            if lows[i] == min(lows[i-3:i+3]):  # local trough
+                segment = highs[i+1:]
+                if len(segment) == 0:
+                    continue
+                highest_after_trough = max(segment)
+                rise = ((highest_after_trough - lows[i] ) / lows[i] ) * 100
+                if segment.size > 0 and rise > momentum_drop:
+                    highest_index_after_peak = i + 1 + np.argmax(segment)
+                    future_closes = closes[i:]
+                    if not np.any(future_closes < lows[i]):
+                        rejection_points.append(lows[i])
+                        rejection_types.append("momentum_rise")
+                        rejection_volumes.append(volumes[i])
+                        i = highest_index_after_peak  # Skip ahead to avoid double counting
+
+
+            # Case 2: Trough + Range -> Rise
+            if i >= 3 and i < len(lows) - 3 and lows[i] == min(lows[i-3:i+3]):  # local trough
+                range_high = np.max(highs[i+1:i+1+range_window])
+                range_low  = np.min(lows[i+1:i+1+range_window])
+                if (range_high - range_low) < atr[i] * range_tolerance:
+                    # rise check after consolidation
+                    if np.any(closes[i+range_window:i+range_window+breakout_confirm] > range_high):
+                        future_closes = closes[i:]
+                        if not np.any(future_closes < lows[i]):
+                            rejection_points.append(lows[i])
+                            rejection_types.append("momentum_rise")
+                            rejection_volumes.append(volumes[i])
+                        
+
+        logger.debug(f"Total Rejection Points Detected: {len(rejection_points)}")
+        return rejection_points, rejection_types, rejection_volumes
+
+    
+    def analyze_clusters_agglomerative(self, rejection_points: List[float], rejection_types: List[str], 
+                                    rejection_volumes: List[float], df: pd.DataFrame, 
+                                    params: ParameterConfig, **kwargs) -> Dict[str, Any]:
+        """Analyze clusters using agglomerative clustering with silhouette score optimization"""
+        logger.debug(f"🔧 Analyzing clusters with agglomerative clustering - {len(rejection_points)} points")
+        
+        if len(rejection_points) < 2:
+            logger.warning("Not enough rejection points for clustering")
+            return {}
+        
+        # Separate support and resistance points
+        resistance_points = []
+        resistance_volumes = []
+        support_points = []
+        support_volumes = []
+
+        if 'support_levels' in kwargs:
+            for levels in  kwargs['support_levels']:
+                support_points.append(levels)
+                support_volumes.append(1)  # No volume data for pre-defined levels
+
+        if 'resistance_levels' in kwargs:
+            for levels in  kwargs['resistance_levels']:
+                resistance_points.append(levels)
+                resistance_volumes.append(1)  # No volume data for pre-defined levels
+
+        logger.cluster(f"🔍 Initial Separation:")
+        logger.resistance(f"   - Initial Resistance points: {(resistance_points)}")
+        logger.support(f"   - Initial Support points: {(support_points)}")
+
+        for i, (point, type_, volume) in enumerate(zip(rejection_points, rejection_types, rejection_volumes)):
+            if type_ in ['upper_wick', 'pivot_high', 'fibonacci_resistance', 'momentum_drop']:# swing_high_support ]:
+                resistance_points.append(point)
+                resistance_volumes.append(volume)
+            elif type_ in ['lower_wick', 'pivot_low', 'fibonacci_support', 'momentum_rise']:# 'swing_low_support']:
+                support_points.append(point)
+                support_volumes.append(volume)
+        
+        logger.cluster(f"🔍 Separated rejection points:")
+        logger.resistance(f"   - Resistance points: {len(resistance_points)}")
+        logger.support(f"   - Support points: {len(support_points)}")
+        
+        # Process resistance zones with agglomerative clustering
+        resistance_zones = self.cluster_points_agglomerative_with_dbscan(
+            resistance_points, resistance_volumes, 'resistance', df, params
+        )
+        
+        # Process support zones with agglomerative clustering
+        support_zones = self.cluster_points_agglomerative_with_dbscan(
+            support_points, support_volumes, 'support', df, params
+        )
+
+        for i, (point, type_, volume) in enumerate(zip(rejection_points, rejection_types, rejection_volumes)):
+            if type_ in ['pivot_high']:
+                resistance_zones.append(point)
+            elif type_ in ['pivot_low']:
+                support_zones.append(point)
+        
+        # Calculate Fibonacci levels
+        # fibonacci_data = calculate_fibonacci_levels(df, params.lookback_period)
+        
+        logger.cluster(f"📊 Final Results:")
+        logger.resistance(f"   - Resistance zones: {[f'{z:.4f}' for z in resistance_zones]}")
+        logger.support(f"   - Support zones: {[f'{z:.4f}' for z in support_zones]}")
+        # logger.fibonacci(f"   - Fibonacci levels: {[f'{z:.4f}' for z in fibonacci_data['fibonacci_levels']]}")
+        
+        # Count rejection point types
+        traditional_resistance = len([p for p, t in zip(rejection_points, rejection_types) if t in ['upper_wick', 'pivot_high']])
+        traditional_support = len([p for p, t in zip(rejection_points, rejection_types) if t in ['lower_wick', 'pivot_low']])
+        fibonacci_resistance = len([p for p, t in zip(rejection_points, rejection_types) if t == 'fibonacci_resistance'])
+        fibonacci_support = len([p for p, t in zip(rejection_points, rejection_types) if t == 'fibonacci_support'])
+        swing_resistance = len([p for p, t in zip(rejection_points, rejection_types) if t == 'swing_high_resistance'])
+        swing_support = len([p for p, t in zip(rejection_points, rejection_types) if t == 'swing_low_support'])
+        
+        logger.debug(f"   - Rejection point breakdown:")
+        logger.debug(f"     * Traditional: {traditional_resistance} resistance, {traditional_support} support")
+        logger.fibonacci(f"     * Fibonacci: {fibonacci_resistance} resistance, {fibonacci_support} support")
+        logger.fibonacci(f"     * Swing: {swing_resistance} resistance, {swing_support} support")
+        
+        return {
+            'resistance_zones': resistance_zones,
+            'support_zones': support_zones,
+            # 'fibonacci_levels': fibonacci_data['fibonacci_levels'],
+            # 'swing_high': fibonacci_data['swing_high'],
+            # 'swing_low': fibonacci_data['swing_low'],
+            # 'price_range': fibonacci_data['price_range'],
+            'clustering_method': 'agglomerative',
+            'linkage_method': params.agglo_linkage
+        }
+
+    @abstractmethod
+    def generate_signals(self) -> Dict[str, Any]:
+        pass
+
+     
+    def find_optimal_clusters_agglomerative(self, points: List[float], max_clusters: int = 10) -> Tuple[int, float]:
+        """Find optimal number of clusters using silhouette score with agglomerative clustering"""
+        if len(points) < 2:
+            return 1, 0.0
+        
+        X = np.array(points).reshape(-1, 1)
+        
+        # Standardize the data
+        scaler = StandardScaler()
+        X_scaled = scaler.fit_transform(X)
+        
+        best_score = -1
+        best_n_clusters = 1
+        
+        # Try different numbers of clusters
+        for n_clusters in range(2, min(max_clusters + 1, len(points))):
+            try:
+                # Perform agglomerative clustering
+                clustering = AgglomerativeClustering(n_clusters=n_clusters)
+                cluster_labels = clustering.fit_predict(X_scaled)
+                
+                # Calculate silhouette score
+                if len(set(cluster_labels)) > 1:  # Need at least 2 clusters for silhouette
+                    score = silhouette_score(X_scaled, cluster_labels)
+                    
+                    if score > best_score:
+                        best_score = score
+                        best_n_clusters = n_clusters
+                        
+                    logger.debug(f"   - {n_clusters} clusters: silhouette score = {score:.4f}")
+            except Exception as e:
+                logger.debug(f"   - Error with {n_clusters} clusters: {e}")
+                continue
+        
+        logger.cluster(f"🔧 Optimal clusters: {best_n_clusters} (silhouette score: {best_score:.4f})")
+        return best_n_clusters, best_score
+
+
+    def calculate_fibonacci_levels(self, df: pd.DataFrame, lookback_period: int = 50) -> Dict[str, List[float]]:
+        """Calculate Fibonacci retracement levels based on swing high and low"""
+        logger.fibonacci(f"Calculating Fibonacci levels with lookback: {lookback_period}")
+        
+        # if len(df) < lookback_period:
+        #     logger.warning(f"Not enough data for Fibonacci calculation. Need {lookback_period}, have {len(df)}")
+        #     return {'fibonacci_levels': [], 'swing_high': None, 'swing_low': None}
+        
+        # Get the recent data
+        recent_data = df.tail(lookback_period)
+        
+        # Find swing high and low
+        swing_high = recent_data['high'].max()
+        swing_low = recent_data['low'].min()
+        
+        # Calculate Fibonacci levels
+        price_range = swing_high - swing_low
+        fibonacci_levels = []
+        
+        # Standard Fibonacci ratios
+        fib_ratios = [0.5, 0.618, 1]
+        
+        for ratio in fib_ratios:
+            level = swing_high - (price_range * ratio)
+            fibonacci_levels.append(level)
+        
+        logger.fibonacci(f"Swing High: {swing_high:.4f}")
+        logger.fibonacci(f"Swing Low: {swing_low:.4f}")
+        logger.fibonacci(f"Price Range: {price_range:.4f}")
+        logger.fibonacci(f"Fibonacci Levels: {[f'{level:.4f}' for level in fibonacci_levels]}")
+        
+        return {
+            'fibonacci_levels': fibonacci_levels,
+            'swing_high': swing_high,
+            'swing_low': swing_low,
+            'price_range': price_range
+        }
+
+
+    def cluster_points_agglomerative_with_dbscan(self, points: List[float], volumes: List[float], zone_type: str, 
+                                            df: pd.DataFrame, params: ParameterConfig) -> List[float]:
+        """Hybrid clustering: Agglomerative clustering followed by DBSCAN noise filtering"""
+        if len(points) < 2:
+            return []
+        
+        logger.cluster(f"🔧 Hybrid clustering (Agglomerative + DBSCAN) for {zone_type} with {len(points)} points")
+        
+        # Step 1: Agglomerative clustering (original approach)
+        optimal_n_clusters, silhouette_score_val = self.find_optimal_clusters_agglomerative(
+            points, max(params.agglo_n_clusters_range)
+        )
+        
+        if optimal_n_clusters == 1:
+            logger.cluster(f"Only one cluster found for {zone_type}")
+            # return []
+        
+        # Prepare data for clustering
+        X = np.array(points).reshape(-1, 1)
+        
+        # Standardize the data
+        scaler = StandardScaler()
+        X_scaled = scaler.fit_transform(X)
+        
+        # Perform agglomerative clustering with optimal number of clusters
+        clustering = AgglomerativeClustering(
+            n_clusters=optimal_n_clusters,
+            linkage=params.agglo_linkage
+        )
+        cluster_labels = clustering.fit_predict(X_scaled)
+        
+        # Analyze agglomerative results
+        unique_labels = set(cluster_labels)
+        n_clusters = len(unique_labels)
+        
+        logger.cluster(f"📊 {zone_type.title()} Agglomerative Results:")
+        logger.debug(f"   - Total points: {len(X)}")
+        logger.debug(f"   - Clusters found: {n_clusters}")
+        logger.debug(f"   - Silhouette score: {silhouette_score_val:.4f}")
+        logger.debug(f"   - Linkage method: {params.agglo_linkage}")
+        
+        # Calculate current price for relevance filtering
+        current_price = df['close'].iloc[-1]
+        price_range = df['high'].max() - df['low'].min()
+        
+        zones = []
+        zone_scores = []
+        
+        for label in unique_labels:
+            # Get points in this cluster
+            cluster_mask = cluster_labels == label
+            cluster_points = np.array(points)[cluster_mask]
+            cluster_volumes = np.array(volumes)[cluster_mask]
+
+            # Volume/recency weighted cluster center – heavier volume and recent touches
+            # exert more influence, reflecting common S/R heuristics (Murphy 1999; Bulkowski 2005)
+            volume_ma = df['volume'].tail(params.volume_ma).mean()
+            volume_weights = cluster_volumes / volume_ma if volume_ma > 0 else np.ones(len(cluster_volumes))
+            recency_weights = np.linspace(params.recency_weight, 1.0, len(cluster_points))
+            weights = volume_weights * recency_weights
+            weighted_center = np.average(cluster_points, weights=weights)
+
+            weighted_center = np.inf
+
+            # Use min/max as fallback if weighting fails
+            if not np.isfinite(weighted_center):
+                weighted_center = np.min(cluster_points) if zone_type == 'support' else np.max(cluster_points)
+            cluster_center = float(round(weighted_center, 2))
+
+            # Calculate cluster strength incorporating weights
+            base_strength = weights.sum()
+            volume_factor = np.mean(cluster_volumes) / volume_ma if volume_ma > 0 else 1.0
+
+            cluster_strength = base_strength * volume_factor
+            
+            # # Volume filter
+            high_volume_touches = sum(1 for vol in cluster_volumes if vol > volume_ma * params.volume_filter_threshold)
+            
+            # Price relevance filter
+            price_distance = abs(cluster_center - current_price) / current_price
+            is_price_relevant = price_distance <= params.price_relevance_threshold
+            
+            # Directional validation
+            if zone_type == 'resistance':
+                is_directionally_correct = cluster_center > current_price
+            else:  # support
+                is_directionally_correct = cluster_center < current_price
+            
+            logger.cluster(f"🔍 {zone_type.title()} Cluster {label} Analysis:")
+            logger.debug(f"   - Center: {cluster_center:.4f}")
+            logger.debug(f"   - Points: {len(cluster_points)}")
+            # logger.debug(f"   - Point values: {[f'{p:.4f}' for p in cluster_points]}")
+            logger.debug(f"   - Strength: {cluster_strength:.2f}")
+            logger.debug(f"   - High volume touches: {high_volume_touches}")
+            logger.debug(f"   - Price distance: {price_distance:.2%}")
+            logger.debug(f"   - Price relevant: {is_price_relevant}")
+            logger.debug(f"   - Directionally correct: {is_directionally_correct}")
+            
+            # Apply filters
+            if (cluster_strength >= params.min_cluster_strength and 
+                # high_volume_touches >= 1 and
+                len(cluster_points) >= params.min_touches_per_zone and
+                is_price_relevant and
+                is_directionally_correct):
+                
+                # Calculate zone score for ranking
+                zone_score = cluster_strength * (1 + volume_factor) * (1 - price_distance)
+                zones.append(cluster_center)
+                zone_scores.append(zone_score)
+                
+                logger.filter_pass(f"   ✅ {zone_type.title()} Cluster {label} PASSED filters")
+                if zone_type == 'resistance':
+                    logger.resistance(f"      → Added as {zone_type.upper()}: {cluster_center:.4f} (score: {zone_score:.2f})")
+                else:
+                    logger.support(f"      → Added as {zone_type.upper()}: {cluster_center:.4f} (score: {zone_score:.2f})")
+            else:
+                logger.filter_fail(f"   ❌ {zone_type.title()} Cluster {label} FAILED filters")
+        
+        # Sort zones by score and limit to max_zones_per_type
+        # if zones and len(zones) > params.max_zones_per_type:
+        #     sorted_indices = sorted(range(len(zone_scores)), key=lambda i: zone_scores[i], reverse=True)
+        #     zones = [zones[i] for i in sorted_indices[:params.max_zones_per_type]]
+        #     zone_scores = [zone_scores[i] for i in sorted_indices[:params.max_zones_per_type]]
+            
+        #     logger.debug(f"   Limited to top {params.max_zones_per_type} zones by score")
+        
+        # Step 2: Apply DBSCAN noise filtering to consolidate nearby zones
+        # if zones and len(zones) > 1 and params.enable_dbscan_filtering:
+        #     logger.cluster(f"🔧 Applying DBSCAN noise filtering to {len(zones)} agglomerative zones")
+        #     zones = apply_dbscan_noise_filtering(zones, zone_type, eps_ratio=params.dbscan_eps_ratio, min_samples=params.dbscan_min_samples)
+        
+        return zones
+
+
+
+    def _bullish_reversal(self, data) -> str:
+        """Detects bullish reversal candlestick patterns."""
+        if len(data) < 3:
+            return
+
+        o1, c1, h1, l1 = data.open.iloc[-1], data.close.iloc[-1], data.high.iloc[-1], data.low.iloc[-1]
+        o2, c2, h2, l2 = data.open.iloc[-2], data.close.iloc[-2], data.high.iloc[-2], data.low.iloc[-2]
+        o3, c3, h3, l3 = data.open.iloc[-3], data.close.iloc[-3], data.high.iloc[-3], data.low.iloc[-3]
+
+        # print(f"Analyzing Bullish Reversal: O1={o1}, C1={c1}, H1={h1}, L1={l1} | O2={o2}, C2={c2}, H2={h2}, L2={l2} | O3={o3}, C3={c3}, H3={h3}, L3={l3}")
+
+        # Common measures
+        body = abs(c1 - o1)
+        lower_wick = min(o1, c1) - l1
+        upper_wick = h1 - max(o1, c1)
+
+        # ---- PATTERNS ----
+        # 1. Bullish Engulfing
+        engulfing = (c2 < o2) and (c1 > o1) and (o1 <= c2) and (c1 >= o2)
+
+        bearish_trend = (c2 < o2) and (c3 < o3)
+
+        # # 2. Hammer / Pin Bar (small body, long lower wick)
+        # hammer_shape = lower_wick > body * 2 and upper_wick < body
+        # bullish_hammer = hammer_shape and bearish_trend
+
+        # 3. Morning Star (three-candle pattern)
+        # red -> small -> strong green closing into 1st candle’s body
+        small_candle = abs(c2 - o2) < (abs(c3 - o3) * 0.5)
+        morning_star = (
+            (c3 < o3) and
+            small_candle and
+            (c1 > o1) and
+            (c1 > (o3 + c3) / 2) and
+            (o2 < c3)  # small gap down improves reliability
+        )
+
+        # 4. Doji + Bullish confirmation
+        doji = abs(c2 - o2) <= (h2 - l2) * 0.1
+        doji_reversal = doji and c1 > o1 and c1 > o2
+
+        if engulfing:
+            return 'engulfing' 
+        # if bullish_hammer:
+        #     return 'bullish_hammer'
+        if morning_star:
+            return 'morning_star'
+        if doji_reversal:
+            return 'doji_reversal'
+
+        return None
+
+
+    def _bearish_reversal(self, data) -> str:
+        """Detects bearish reversal candlestick patterns."""
+        if len(data) < 3:
+            return
+        
+        o1, c1, h1, l1 = data.open.iloc[-1], data.close.iloc[-1], data.high.iloc[-1], data.low.iloc[-1]
+        o2, c2, h2, l2 = data.open.iloc[-2], data.close.iloc[-2], data.high.iloc[-2], data.low.iloc[-2]
+        o3, c3, h3, l3 = data.open.iloc[-3], data.close.iloc[-3], data.high.iloc[-3], data.low.iloc[-3]
+
+        # print(f"Analyzing Bearish Reversal: O1={o1}, C1={c1}, H1={h1}, L1={l1} | O2={o2}, C2={c2}, H2={h2}, L2={l2} | O3={o3}, C3={c3}, H3={h3}, L3={l3}")
+
+        body = abs(c1 - o1)
+        upper_wick = h1 - max(o1, c1)
+        lower_wick = min(o1, c1) - l1
+
+        # ---- PATTERNS ----
+        # 1. Bearish Engulfing
+        engulfing = c2 > o2 and c1 < o1 and c1 <= o2 and o1 >= c2
+
+        # 2. Shooting Star (long upper wick, small body)
+        shooting_star =  upper_wick > body * 2 and lower_wick < body
+
+        # 3. Evening Star (green -> small -> strong red)
+        small_candle = abs(c2 - o2) < (abs(c3 - o3) * 0.5)
+        evening_star = (
+            c3 > o3 and
+            small_candle and
+            c1 < o1 and
+            c1 < ((o3 + c3) / 2) and
+            o2 > c3  # small gap up
+        )
+
+        # 4. Doji + Bearish confirmation
+        doji = abs(c2 - o2) <= (h2 - l2) * 0.1
+        doji_reversal = doji and c1 < o1 and c1 < o2
+
+
+        if engulfing:
+            return 'engulfing' 
+        if shooting_star:
+            return 'shooting_star'
+        if evening_star:
+            return 'evening_star'
+        if doji_reversal:
+            return 'doji_reversal'
+
+
+        return None
+
+
+class Agglo_ETHERIUM(AggloBase):
+    """
+    A strategy based on the Price Reversal
+    """
+    def __init__(self, data: pd.DataFrame):
+        super().__init__(data)
+        self.persistence = AggloBase.PersistencePlugin(redis_client=self.redis_client, class_name=self.__class__.__name__)
+        logger.info("Agglo_ETHERIUM initialized")
+
+    def generate_signals(self, symbol=None):
+        """
+        Implement the Reversal logic to generate signals.
+
+        Returns:
+            BUY, SELL OR NONE
+        """
+
+        swing_lookback = 30
+        swing_lookback_window = 5
+        tol = 0.5
+        rr = 4
+        atr_period = 14
+        sl_atr_mul = 3
+        momentum_drop = 4
+
+
+        params =  AggloBase.ParameterConfig()
+        params.evalution_tolerance_factor = tol
+        params.rejection_atr_mul = 1.5
+        params.swing_lookback = swing_lookback
+        params.swing_window = swing_lookback_window
+        params.momentum_drop = momentum_drop
+
+        lookback_df = self.data.iloc[-params.lookback_period:].copy()
+        current_idx = len(self.data) - 1
+    
+        self.zones = self.SR_levls_implementation(self.data, self.persistence, params, window_end=current_idx)
+        self.send_levels_info(data=None, description=f"Symbol = ETHERIUM", fields=self.zones)
+
+        open_ = lookback_df['open'].iloc[-1]
+        close = round(lookback_df['close'].iloc[-1], 1)
+        high = lookback_df['high'].iloc[-1]
+        low = lookback_df['low'].iloc[-1]
+
+        atr = self.calculate_atr(data=lookback_df, period=atr_period).iloc[-1]
+        tol = atr * tol
+        extra_params = {
+            'atr': atr,
+            'region_tolerance': tol,
+        }
+        self.send_params(stock_df=lookback_df, symbol=symbol, duration="15 MIN", **extra_params)
+
+        for zone in self.zones["resistance"]:
+
+            bearish_reversal = self._bearish_reversal(lookback_df)
+
+            if (low <= zone + tol) and (high >= zone - tol) and bearish_reversal:
+                # atr_stop = close +  atr * self.p.sl_atr_mult
+                stop = self.find_swing_high(lookback_df.iloc[-swing_lookback:], swing_lookback_window) + atr * sl_atr_mul
+                stop = max(stop, zone)
+                risk = stop - close 
+                target = close - risk * rr
+                self.trade_type = f'Resistance reversal {bearish_reversal}'
+                chart_path_raw = generate_chart(lookback_df)
+                return {
+                    "signal": "SELL",
+                    "entry_price": close,
+                    "stop_loss": stop,
+                    "take_profit": target,
+                    "chart_path": None,
+                    "chart_path_raw": chart_path_raw,
+                    "pattern": self.trade_type
+                }
+             
+            if zone >= open_ and zone <= close:
+                stop = self.find_swing_low(lookback_df.iloc[-swing_lookback:], swing_lookback_window)                
+                risk = close - stop 
+                target = close + risk * rr
+                self.trade_type = 'Resistance breakout'
+                chart_path_raw = generate_chart(lookback_df)
+                return {
+                    "signal": "BUY",
+                    "entry_price": close,
+                    "stop_loss": stop,
+                    "take_profit": target,
+                    "chart_path": None,
+                    "chart_path_raw": chart_path_raw,
+                    "pattern": self.trade_type
+                }          
+                  
+        for zone in self.zones["support"]:
+
+            bullish_reversal = self._bullish_reversal(lookback_df)
+
+            if (low <= zone + tol) and (high >= zone - tol) and bullish_reversal:
+                stop = self.find_swing_low(lookback_df.iloc[-swing_lookback:], swing_lookback_window) - atr * sl_atr_mul      
+                stop = min(stop, zone)
+                risk = close - stop 
+                target = close + risk * rr
+                self.trade_type = f'Support Reversal {bullish_reversal}'
+                chart_path_raw = generate_chart(lookback_df)
+                return {
+                    "signal": "BUY",
+                    "entry_price": close,
+                    "stop_loss": stop,
+                    "take_profit": target,
+                    "chart_path": None,
+                    "chart_path_raw": chart_path_raw,
+                    "pattern": self.trade_type
+                }
+    
+            if zone <= open_ and zone >= close:
+                # atr_stop = close +  atr * self.p.sl_atr_mult
+                stop = self.find_swing_high(lookback_df.iloc[-swing_lookback:], swing_lookback_window)
+                risk = stop - close 
+                target = close - risk * rr
+                self.trade_type = 'Support breakout'
+                chart_path_raw = generate_chart(lookback_df)
+                return {
+                    "signal": "SELL",
+                    "entry_price": close,
+                    "stop_loss": stop,
+                    "take_profit": target,
+                    "chart_path": None,
+                    "chart_path_raw": chart_path_raw,
+                    "pattern": self.trade_type
+                }
+            
+
+
+        return None
+    
+

--- a/src/orbit/strategies/reversal_strategy.py
+++ b/src/orbit/strategies/reversal_strategy.py
@@ -1,0 +1,148 @@
+import pandas as pd
+
+from orbit.strategies.strategies_base import Strategy
+from orbit.utils.utils import generate_chart
+
+
+class BollingerAdaptiveReversalStrategyBCH(Strategy):
+    """
+    Bollinger Band Reversal Strategy for BCH based on backtesting results.
+    Uses Bollinger Bands with reversal patterns (engulfing, hammer, shooting star).
+    """
+    
+    def __init__(self, data: pd.DataFrame, 
+                 bb_period=20, bb_devfactor=3.0, sma_period=20, sl_pct=0.015):
+        super().__init__(data)
+        self.bb_period = bb_period
+        self.bb_devfactor = bb_devfactor
+        self.sma_period = sma_period
+        self.sl_pct = sl_pct
+        print("BollingerReversalStrategyBCH initialized")
+
+    def compute_bollinger_bands(self, close_series):
+        """Compute Bollinger Bands"""
+        sma = close_series.rolling(window=self.bb_period).mean()
+        std = close_series.rolling(window=self.bb_period).std()
+        upper_band = sma + (self.bb_devfactor * std)
+        middle_band = sma
+        lower_band = sma - (self.bb_devfactor * std)
+        return upper_band, middle_band, lower_band
+
+    def compute_sma(self, close_series):
+        """Compute Simple Moving Average"""
+        return close_series.rolling(window=self.sma_period).mean()
+
+    def is_bullish_reversal(self, df):
+        """Detect bullish reversal patterns"""
+        if len(df) < 2:
+            return False
+            
+        close = df['close'].iloc[-1]
+        open_ = df['open'].iloc[-1]
+        low = df['low'].iloc[-1]
+        high = df['high'].iloc[-1]
+
+        prev_close = df['close'].iloc[-2]
+        prev_open = df['open'].iloc[-2]
+
+        # Bullish Engulfing: current candle engulfs previous red candle
+        bullish_engulfing = (prev_close < prev_open) and (close > open_) and (close > prev_open) and (open_ < prev_close)
+
+        # Hammer: small body, long lower shadow
+        body = abs(close - open_)
+        shadow = low < min(close, open_)
+        hammer = shadow and ((min(close, open_) - low) > 2 * body)
+
+        return bullish_engulfing or hammer
+
+    def is_bearish_reversal(self, df):
+        """Detect bearish reversal patterns"""
+        if len(df) < 2:
+            return False
+            
+        close = df['close'].iloc[-1]
+        open_ = df['open'].iloc[-1]
+        low = df['low'].iloc[-1]
+        high = df['high'].iloc[-1]
+
+        prev_close = df['close'].iloc[-2]
+        prev_open = df['open'].iloc[-2]
+
+        # Bearish Engulfing: current candle engulfs previous green candle
+        bearish_engulfing = (prev_close > prev_open) and (close < open_) and (close < prev_open) and (open_ > prev_close)
+
+        # Shooting Star: small body, long upper shadow
+        body = abs(close - open_)
+        shadow = high > max(close, open_)
+        shooting_star = shadow and ((high - max(close, open_)) > 2 * body)
+
+        return bearish_engulfing or shooting_star
+
+    def generate_signals(self, symbol=None):
+        """
+        Generate trading signals based on Bollinger Band reversals.
+        
+        Returns:
+            Signal dict with entry_price, stop_loss, take_profit, or None
+        """
+        lookup = 168
+        df_15min = self.data.iloc[-lookup:]
+        self.send_params(stock_df=df_15min, symbol=symbol, duration="15 MIN")
+
+        close = df_15min['close']
+        current_close = close.iloc[-1]
+        prev_close = close.iloc[-2] if len(close) > 1 else current_close
+
+        # Calculate indicators
+        bb_upper, bb_middle, bb_lower = self.compute_bollinger_bands(close)
+        sma = self.compute_sma(close)
+
+        # Check if we have enough data for indicators
+        if bb_upper.iloc[-1] is None or bb_lower.iloc[-1] is None or sma.iloc[-1] is None:
+            return None
+
+        current_bb_upper = bb_upper.iloc[-1]
+        current_bb_lower = bb_lower.iloc[-1]
+        current_sma = sma.iloc[-1]
+        prev_bb_upper = bb_upper.iloc[-2] if len(bb_upper) > 1 else current_bb_upper
+        prev_bb_lower = bb_lower.iloc[-2] if len(bb_lower) > 1 else current_bb_lower
+
+        # LONG Entry: previous candle closed below lower band and current is bullish reversal
+        if (prev_close < prev_bb_lower and 
+            current_close > current_bb_lower and 
+            self.is_bullish_reversal(df_15min)):
+            
+            entry_price = current_close
+            stop_loss = entry_price * (1 - self.sl_pct)
+            
+            chart_path_raw = generate_chart(df_15min)
+            return {
+                "signal": "BUY",
+                "entry_price": entry_price,
+                "stop_loss": stop_loss,
+                "take_profit": None,
+                "pattern": "Bollinger Band Bullish Reversal",
+                "chart_path": None,
+                "chart_path_raw": chart_path_raw
+            }
+
+        # SHORT Entry: previous candle closed above upper band and current is bearish reversal
+        elif (prev_close > prev_bb_upper and 
+              current_close < current_bb_upper and 
+              self.is_bearish_reversal(df_15min)):
+            
+            entry_price = current_close
+            stop_loss = entry_price * (1 + self.sl_pct)            
+
+            chart_path_raw = generate_chart(df_15min)
+            return {
+                "signal": "SELL",
+                "entry_price": entry_price,
+                "stop_loss": stop_loss,
+                "take_profit": None,
+                "pattern": "Bollinger Band Bearish Reversal",
+                "chart_path": None,
+                "chart_path_raw": chart_path_raw
+            }
+
+        return None

--- a/src/orbit/strategies/strategies_base.py
+++ b/src/orbit/strategies/strategies_base.py
@@ -43,4 +43,34 @@ class Strategy(DiscordManager, ABC):
             description=f"{symbol} {duration} Candlestick update",
             fields=params,
         )
-    
+
+    @staticmethod
+    def calculate_atr(data: pd.DataFrame, period: int = 14) -> pd.Series:
+        """Return a rolling average true range used by production strategies."""
+        previous_close = data["close"].shift(1)
+        true_range = pd.concat(
+            [
+                data["high"] - data["low"],
+                (data["high"] - previous_close).abs(),
+                (data["low"] - previous_close).abs(),
+            ],
+            axis=1,
+        ).max(axis=1)
+        return true_range.rolling(window=period, min_periods=1).mean()
+
+    @staticmethod
+    def compute_ema(series: pd.Series, period: int = 200) -> pd.Series:
+        return series.ewm(span=period, adjust=False).mean()
+
+    @staticmethod
+    def compute_atr(data: pd.DataFrame, period: int = 14) -> pd.Series:
+        previous_close = data["close"].shift(1)
+        true_range = pd.concat(
+            [
+                data["high"] - data["low"],
+                (data["high"] - previous_close).abs(),
+                (data["low"] - previous_close).abs(),
+            ],
+            axis=1,
+        ).max(axis=1)
+        return true_range.rolling(window=period).mean()

--- a/src/orbit/strategies/strategy_registry.py
+++ b/src/orbit/strategies/strategy_registry.py
@@ -1,6 +1,8 @@
 import yaml
 import importlib
 import logging
+import os
+from importlib import metadata
 
 logger = logging.getLogger(__name__)
 
@@ -13,7 +15,8 @@ def load_class(path: str):
 
 def _load_config():
     try:
-        with open("config/strategies.yaml") as f:
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+        with open(os.path.join(project_root, "config", "strategies.yaml"), encoding="utf-8") as f:
             return yaml.safe_load(f)
     except FileNotFoundError:
         logger.warning("config/strategies.yaml not found; strategy registry will be empty.")
@@ -30,15 +33,29 @@ class _LazyStrategyRegistry(dict):
             symbol: item["strategy"]
             for symbol, item in config.get("strategies", {}).items()
         }
+        self._expected_versions = {
+            symbol: item.get("expected_package_version")
+            for symbol, item in config.get("strategies", {}).items()
+        }
 
     def _resolve(self, symbol: str):
         path = self._raw[symbol]
         try:
+            expected = self._expected_versions.get(symbol)
+            if expected:
+                try:
+                    installed = metadata.version("orbit-strategies")
+                except metadata.PackageNotFoundError:
+                    installed = "development"
+                if installed not in (expected, "development"):
+                    raise RuntimeError(
+                        f"orbit-strategies {installed} installed; {expected} required for {symbol}"
+                    )
             cls = load_class(path)
             # Cache the resolved class so we only import once
             super().__setitem__(symbol, cls)
             return cls
-        except (ModuleNotFoundError, AttributeError) as exc:
+        except (ModuleNotFoundError, AttributeError, RuntimeError) as exc:
             logger.error(
                 "Could not load strategy '%s' for symbol '%s': %s", path, symbol, exc
             )
@@ -73,7 +90,7 @@ class _LazyStrategyRegistry(dict):
         if symbol in self._raw:
             try:
                 return self[symbol]
-            except (ModuleNotFoundError, AttributeError):
+            except (ModuleNotFoundError, AttributeError, RuntimeError):
                 return default
         return default
 

--- a/src/orbit/strategies/strategy_registry.py
+++ b/src/orbit/strategies/strategy_registry.py
@@ -2,7 +2,6 @@ import yaml
 import importlib
 import logging
 import os
-from importlib import metadata
 
 logger = logging.getLogger(__name__)
 
@@ -33,29 +32,15 @@ class _LazyStrategyRegistry(dict):
             symbol: item["strategy"]
             for symbol, item in config.get("strategies", {}).items()
         }
-        self._expected_versions = {
-            symbol: item.get("expected_package_version")
-            for symbol, item in config.get("strategies", {}).items()
-        }
 
     def _resolve(self, symbol: str):
         path = self._raw[symbol]
         try:
-            expected = self._expected_versions.get(symbol)
-            if expected:
-                try:
-                    installed = metadata.version("orbit-strategies")
-                except metadata.PackageNotFoundError:
-                    installed = "development"
-                if installed not in (expected, "development"):
-                    raise RuntimeError(
-                        f"orbit-strategies {installed} installed; {expected} required for {symbol}"
-                    )
             cls = load_class(path)
             # Cache the resolved class so we only import once
             super().__setitem__(symbol, cls)
             return cls
-        except (ModuleNotFoundError, AttributeError, RuntimeError) as exc:
+        except (ModuleNotFoundError, AttributeError) as exc:
             logger.error(
                 "Could not load strategy '%s' for symbol '%s': %s", path, symbol, exc
             )
@@ -90,7 +75,7 @@ class _LazyStrategyRegistry(dict):
         if symbol in self._raw:
             try:
                 return self[symbol]
-            except (ModuleNotFoundError, AttributeError, RuntimeError):
+            except (ModuleNotFoundError, AttributeError):
                 return default
         return default
 

--- a/src/orbit/strategies/swing_strategy.py
+++ b/src/orbit/strategies/swing_strategy.py
@@ -1,0 +1,275 @@
+import os
+import sys
+import math
+import numpy as np
+import pandas as pd
+import redis
+from orbit.utils.utils import generate_chart
+from orbit.strategies.strategies_base import Strategy
+from typing import List, Optional, Dict, Any
+from dataclasses import dataclass, field
+import logging
+
+logger = logging.getLogger("Orbit")
+
+@dataclass
+class SwingStrategyBTC(Strategy):
+    """
+    Real-time Swing Strategy matching Backtrader logic:
+    - EMA200 Trend Filter
+    - Pivot breakout entries
+    - ATR Structural SL
+    - RR = 1:2 TP
+    - Non-repainting pivots
+    """
+
+    data: pd.DataFrame
+
+    # Strategy parameters
+    max_sl_limit: float = 2.0     # %
+    atr_mult: float = 1.0
+    tp_rr: float = 2.0            # target = entry + (2 × risk)
+    n: int = 10
+    symbol: str = "BITCOIN"
+
+    # Runtime state (not constructor args)
+    redis_client: Optional[redis.StrictRedis] = field(init=False, default=None)
+    last_sw_h: Optional[float] = field(init=False, default=None)
+    last_sw_l: Optional[float] = field(init=False, default=None)
+
+    def __post_init__(self):
+        # Initialize base Strategy (sets self.data)
+        super().__init__(self.data)
+        try:
+            self.redis_client = redis.StrictRedis(
+                host=os.getenv("REDIS_HOST", "localhost"),
+                port=int(os.getenv("REDIS_PORT", "6379")),
+                db=int(os.getenv("REDIS_DB", "0")),
+                decode_responses=True,
+            )
+        except Exception as e:
+            logger.error(f"Redis connection error: {e}")
+            self.redis_client = None
+
+        self.last_sw_h = None
+        self.last_sw_l = None
+
+    # ---------------------------------------------------------------------
+    # Redis helpers
+    # ---------------------------------------------------------------------
+    def _get_redis_key(self, key_type: str) -> str:
+        return f"swing:{key_type}:{self.symbol}:4h"
+
+    def _load_last_pivots(self):
+        try:
+            ph = self.redis_client.get(self._get_redis_key("pivot_high"))
+            pl = self.redis_client.get(self._get_redis_key("pivot_low"))
+            return (float(ph) if ph else None, float(pl) if pl else None)
+        except:
+            return (None, None)
+
+    def _save_pivots(self, ph, pl):
+        try:
+            if ph is not None:
+                self.redis_client.set(self._get_redis_key("pivot_high"), str(ph))
+            if pl is not None:
+                self.redis_client.set(self._get_redis_key("pivot_low"), str(pl))
+        except:
+            pass
+
+    # ---------------------------------------------------------------------
+    # Pivot detection
+    # ---------------------------------------------------------------------
+    def pivot_high_centered(self, series, left, right):
+        if len(series) < left + right + 1:
+            return None
+        window = series[-(left+right+1):]
+        center = window[left]
+        return center if center == max(window) else None
+
+    def pivot_low_centered(self, series, left, right):
+        if len(series) < left + right + 1:
+            return None
+        window = series[-(left+right+1):]
+        center = window[left]
+        return center if center == min(window) else None
+
+    # ---------------------------------------------------------------------
+    # SL / TP identical to Backtrader
+    # ---------------------------------------------------------------------
+    def compute_long_sl_tp(self, close):
+        fixed_sl = close * (1 - self.max_sl_limit / 100)
+        atr_val = float(self.atr.iloc[-1])
+        struct_sl = self.last_sw_l - atr_val * self.atr_mult if self.last_sw_l else fixed_sl
+        long_sl = max(fixed_sl, struct_sl)
+
+        risk = close - long_sl
+        long_tp = close + self.tp_rr * risk
+
+        return long_sl, long_tp
+
+    def compute_short_sl_tp(self, close):
+        fixed_sl = close * (1 + self.max_sl_limit / 100)
+        atr_val = float(self.atr.iloc[-1])
+        struct_sl = self.last_sw_h + atr_val * self.atr_mult if self.last_sw_h else fixed_sl
+        short_sl = min(fixed_sl, struct_sl)
+
+        risk = short_sl - close
+        short_tp = close - self.tp_rr * risk
+
+        return short_sl, short_tp
+    
+        # ---------------------------------------------------------------------
+    # Pine-style trailing SL/TP update (matches Backtrader)
+    # ---------------------------------------------------------------------
+    def update_trailing_sl_tp(self, close: float, position_side: str = None) -> Optional[Dict[str, float]]:
+        """
+        Recompute SL/TP every bar and tighten only.
+        """
+
+        stop_loss, take_profit = None, None
+        if position_side == "LONG":
+            stop_loss, take_profit = self.compute_long_sl_tp(close)
+
+        elif position_side == "SHORT":
+            stop_loss, take_profit = self.compute_short_sl_tp(close)
+
+        logger.info(
+            f"[TRAIL UPDATE] {self.symbol} {position_side} "
+            f"SL={stop_loss:.2f} TP={take_profit:.2f}"
+        )
+
+        return {
+            "stop_loss": stop_loss,
+            "take_profit": take_profit,
+        }
+
+
+    # ---------------------------------------------------------------------
+    # Main Signal Generator
+    # ---------------------------------------------------------------------
+    def generate_signals(self, symbol=None, position_side=None) -> Optional[Dict[str, Any]]:
+        lookup = 168
+
+        # -----------------------
+        # RESAMPLE TO 4H
+        # -----------------------
+        df_4h = (
+            self.data.resample("4h")
+            .agg({
+                "open": "first",
+                "high": "max",
+                "low": "min",
+                "close": "last",
+                "volume": "sum",
+            })
+        )
+
+        # Keep only complete 4h periods
+        df_4h = df_4h[self.data.resample("4h").size() == 16]
+        lookback_4h = df_4h.iloc[-lookup:]
+        close = df_4h['close'].iloc[-1]
+        open_ = df_4h['open'].iloc[-1]
+
+        # -----------------------
+        # ATR
+        # -----------------------
+        self.atr = self.compute_atr(df_4h)
+
+        # =====================================================
+        # TRAILING STOP UPDATE (when already in position)
+        # =====================================================
+        if position_side:
+            trail = self.update_trailing_sl_tp(close, position_side=position_side)
+            if trail:
+                return {
+                    "signal": "UPDATE_SL_TP",
+                    "stop_loss": trail["stop_loss"],
+                    "take_profit": trail["take_profit"],
+                }
+
+        
+        last_time = df_4h.index[-1]
+        now = self.data.index[-1]
+
+        logger.info(f"Last 4H candle time: {last_time}, Current time: {now}")
+        logger.info(f"Time since last 4H candle: {(now - last_time).total_seconds() } seconds")
+
+        if (now - last_time).total_seconds() != 13500: # 3h45m = 13500s, ensures we only generate signal once per new 4H candle after it has fully formed
+            return None  # candle still forming based on (open candle timstamp)
+
+        self.send_params(stock_df=df_4h, symbol=symbol, duration="4 HOURS")
+
+
+        # -----------------------
+        # EMA200 TREND FILTER
+        # -----------------------
+        ema200 = self.compute_ema(df_4h["close"], 200)
+        ema200_now = float(ema200.iloc[-1])
+
+        # -----------------------
+        # Pivots
+        # -----------------------
+        highs = df_4h["high"].tolist()[-(2*self.n+1):]
+        lows  = df_4h["low"].tolist()[-(2*self.n+1):]
+
+        # load previous pivots
+        self.last_sw_h, self.last_sw_l = self._load_last_pivots()
+
+        ph = self.pivot_high_centered(highs, self.n, self.n)
+        pl = self.pivot_low_centered(lows, self.n, self.n)
+
+        if ph is not None:
+            self.last_sw_h = ph
+        if pl is not None:
+            self.last_sw_l = pl
+            
+        logger.info(f"Last Pivot High: {self.last_sw_h}, Last Pivot Low: {self.last_sw_l}")
+        self.send_levels_info(data=None, description=f"Symbol = BITCOIN", fields={'swing_high': self.last_sw_h, 'swing_low': self.last_sw_l})
+
+        # save pivots
+        self._save_pivots(self.last_sw_h, self.last_sw_l)
+
+        # -----------------------
+        # Entry Conditions (same as BT)
+        # -----------------------
+        long_signal  = (self.last_sw_h is not None) and (close > self.last_sw_h) and (open_ < self.last_sw_h)
+        short_signal = (self.last_sw_l is not None) and (close < self.last_sw_l) and (open_ > self.last_sw_l)
+
+        stop, target = None, None
+
+        if long_signal:
+            stop, target = self.compute_long_sl_tp(close)
+        elif short_signal:
+            stop, target = self.compute_short_sl_tp(close)
+
+        # -----------------------
+        # Return Signal
+        # -----------------------
+        if long_signal:
+            chart_path_raw = generate_chart(lookback_4h)
+            logger.info(f"Generated LONG signal for {self.symbol} at {close}, SL: {stop}, TP: {target}")
+            return {
+                "signal": "BUY",
+                "entry_price": close,
+                "stop_loss": stop,
+                "take_profit": target,
+                "chart_path": None,
+                "chart_path_raw": chart_path_raw,
+                "pattern": "Long Swing"
+            }
+
+        if short_signal:
+            chart_path_raw = generate_chart(lookback_4h)
+            logger.info(f"Generated SHORT signal for {self.symbol} at {close}, SL: {stop}, TP: {target}")
+            return {
+                "signal": "SELL",
+                "entry_price": close,
+                "stop_loss": stop,
+                "take_profit": target,
+                "chart_path": None,
+                "chart_path_raw": chart_path_raw,
+                "pattern": "Short Swing"
+            }
+
+        return None

--- a/strategy-requirements.txt
+++ b/strategy-requirements.txt
@@ -1,0 +1,2 @@
+# Production strategy dependency pinned to the audited commit (package v1.0.4).
+orbit-strategies @ git+https://github.com/ipankaj18/Orbit-Strategies.git@c824fc9

--- a/strategy-requirements.txt
+++ b/strategy-requirements.txt
@@ -1,2 +1,0 @@
-# Production strategy dependency pinned to the audited commit (package v1.0.4).
-orbit-strategies @ git+https://github.com/ipankaj18/Orbit-Strategies.git@c824fc9

--- a/tests/test_backtesting_engine.py
+++ b/tests/test_backtesting_engine.py
@@ -1,0 +1,56 @@
+import unittest
+
+import pandas as pd
+
+from orbit.backtesting import WalkForwardBacktester
+
+
+class _OneShotStrategy:
+    def __init__(self, data):
+        self.data = data
+
+    def generate_signals(self, symbol=None):
+        if len(self.data) == 2:
+            return {
+                "signal": "BUY", "entry_price": 100, "stop_loss": 98,
+                "take_profit": 104, "pattern": "test",
+            }
+        return None
+
+
+class TestWalkForwardBacktester(unittest.TestCase):
+    def test_fee_aware_target_trade(self):
+        data = pd.DataFrame(
+            {
+                "open": [100, 100, 100], "high": [101, 101, 105],
+                "low": [99, 99, 99], "close": [100, 100, 104],
+                "volume": [1, 1, 1],
+            },
+            index=pd.date_range("2026-01-01", periods=3, freq="15min"),
+        )
+        report = WalkForwardBacktester(
+            _OneShotStrategy, starting_equity=1000, fee_rate=0, slippage_bps=0
+        ).run(data, symbol="BTCUSDT", warmup_bars=1)
+        self.assertEqual(report.trades, 1)
+        self.assertEqual(report.results[0].outcome, "target")
+        self.assertAlmostEqual(report.net_pnl, 20)
+
+    def test_same_bar_stop_and_target_uses_stop(self):
+        data = pd.DataFrame(
+            {
+                "open": [100, 100, 100], "high": [101, 101, 105],
+                "low": [99, 99, 97], "close": [100, 100, 100],
+                "volume": [1, 1, 1],
+            },
+            index=pd.date_range("2026-01-01", periods=3, freq="15min"),
+        )
+        report = WalkForwardBacktester(
+            _OneShotStrategy, starting_equity=1000, fee_rate=0, slippage_bps=0
+        ).run(data, symbol="BTCUSDT", warmup_bars=1)
+        self.assertEqual(report.results[0].outcome, "stop")
+        self.assertAlmostEqual(report.net_pnl, -10)
+
+
+if __name__ == "__main__":
+    unittest.main()
+

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from timeout_decorator import timeout
 from unittest.mock import AsyncMock, patch, MagicMock, call
+from orbit.core.execution import ExecutionMode, ExecutionSettings
 
 os.environ["GROQ_API_KEY"] = "test_key"
 os.environ["LANGCHAIN_API_KEY"] = "test_key"
@@ -73,6 +74,9 @@ def _make_order_manager():
             redis_client=redis_client,
             spot_client=spot,
             futures_client=futures,
+            execution_settings=ExecutionSettings(
+                ExecutionMode.TESTNET, "test", "test", "https://demo-fapi.binance.com"
+            ),
         )
         # disable inherited discord calls
         om.send_to_webhook = MagicMock()
@@ -103,6 +107,9 @@ def _make_trade_checker():
             redis_client=redis_client,
             spot_client=spot,
             futures_client=futures,
+            execution_settings=ExecutionSettings(
+                ExecutionMode.TESTNET, "test", "test", "https://demo-fapi.binance.com"
+            ),
         )
     return tc
 

--- a/tests/test_execution_risk_performance.py
+++ b/tests/test_execution_risk_performance.py
@@ -1,0 +1,92 @@
+import os
+import unittest
+from unittest.mock import patch
+
+from orbit.core.execution import ExecutionMode, ExecutionSettings, FUTURES_TESTNET_URL
+from orbit.core.performance import PerformanceTracker
+from orbit.core.risk_manager import PreTradeRiskGuard
+
+
+class TestExecutionSettings(unittest.TestCase):
+    def test_safe_default_is_paper(self):
+        with patch.dict(os.environ, {}, clear=True):
+            settings = ExecutionSettings.from_env()
+        self.assertEqual(settings.mode, ExecutionMode.PAPER)
+        self.assertFalse(settings.can_submit_orders)
+
+    def test_testnet_uses_separate_credentials(self):
+        env = {
+            "ORBIT_EXECUTION_MODE": "testnet",
+            "BINANCE_TESTNET_API_KEY": "key",
+            "BINANCE_TESTNET_SECRET_KEY": "secret",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = ExecutionSettings.from_env()
+        self.assertEqual(settings.futures_base_url, FUTURES_TESTNET_URL)
+        self.assertTrue(settings.can_submit_orders)
+
+    def test_live_requires_acknowledgement(self):
+        env = {
+            "ORBIT_EXECUTION_MODE": "live",
+            "BINANCE_API_KEY": "key",
+            "BINANCE_SECRET_KEY": "secret",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(RuntimeError):
+                ExecutionSettings.from_env()
+
+
+class TestRiskGuard(unittest.TestCase):
+    def setUp(self):
+        self.guard = PreTradeRiskGuard({
+            "max_leverage": 3,
+            "max_position_notional_pct": 0.5,
+            "max_risk_per_trade_pct": 0.01,
+            "max_daily_loss_pct": 0.02,
+            "min_reward_risk_ratio": 1.5,
+        })
+
+    def test_accepts_bounded_trade(self):
+        result = self.guard.evaluate(
+            equity=1000, entry_price=100, stop_loss=98,
+            take_profit=104, quantity=2, leverage=2, side="BUY",
+        )
+        self.assertTrue(result.allowed)
+
+    def test_rejects_daily_loss_limit(self):
+        result = self.guard.evaluate(
+            equity=1000, entry_price=100, stop_loss=98,
+            take_profit=104, quantity=2, leverage=2, side="BUY", daily_net_pnl=-20,
+        )
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.reason, "daily_loss_limit")
+
+    def test_rejects_poor_reward_risk(self):
+        result = self.guard.evaluate(
+            equity=1000, entry_price=100, stop_loss=98,
+            take_profit=101, quantity=2, leverage=2, side="BUY",
+        )
+        self.assertEqual(result.reason, "reward_risk_below_minimum")
+
+    def test_rejects_stop_on_wrong_side(self):
+        result = self.guard.evaluate(
+            equity=1000, entry_price=100, stop_loss=101,
+            take_profit=104, quantity=2, leverage=2, side="BUY",
+        )
+        self.assertEqual(result.reason, "stop_on_wrong_side")
+
+
+class TestPerformanceTracker(unittest.TestCase):
+    def test_net_return_includes_fees_and_funding(self):
+        records = [
+            {"incomeType": "REALIZED_PNL", "income": "25"},
+            {"incomeType": "COMMISSION", "income": "-2"},
+            {"incomeType": "FUNDING_FEE", "income": "-1"},
+        ]
+        summary = PerformanceTracker.summarize(records, starting_equity=1000)
+        self.assertEqual(summary.net_pnl, 22)
+        self.assertAlmostEqual(summary.return_pct, 2.2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_production_strategies.py
+++ b/tests/test_production_strategies.py
@@ -1,0 +1,29 @@
+import unittest
+
+from orbit.strategies.agglo_strategy import Agglo_ETHERIUM
+from orbit.strategies.reversal_strategy import BollingerAdaptiveReversalStrategyBCH
+from orbit.strategies.strategies_base import Strategy
+from orbit.strategies.strategy_registry import STRATEGY_REGISTRY
+from orbit.strategies.swing_strategy import SwingStrategyBTC
+
+
+class TestProductionStrategyOwnership(unittest.TestCase):
+    def test_registry_resolves_internal_classes(self):
+        self.assertIs(STRATEGY_REGISTRY["BTCUSDT"], SwingStrategyBTC)
+        self.assertIs(STRATEGY_REGISTRY["ETHUSDT"], Agglo_ETHERIUM)
+        self.assertIs(
+            STRATEGY_REGISTRY["BCHUSDT"], BollingerAdaptiveReversalStrategyBCH
+        )
+
+    def test_all_production_strategies_use_orbit_contract(self):
+        for strategy_class in (
+            SwingStrategyBTC,
+            Agglo_ETHERIUM,
+            BollingerAdaptiveReversalStrategyBCH,
+        ):
+            self.assertTrue(issubclass(strategy_class, Strategy))
+            self.assertTrue(strategy_class.__module__.startswith("orbit.strategies."))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- consolidate the production BTC, ETH, and BCH strategies into Orbit
- add a shared walk-forward backtester using the production strategy contract
- remove the private Orbit-Strategies runtime and CI dependency
- add explicit paper, Binance Futures Testnet, and guarded live execution modes
- replace hard-coded BTC quantity with wallet-equity and stop-distance sizing
- enforce leverage, exposure, per-trade risk, daily-loss, reward/risk, stop-side, and target-side limits
- persist accepted, rejected, no-signal, cooldown, error, and execution events in MongoDB
- attribute decisions and Binance client order IDs to the executing Orbit version
- synchronize realized PnL, commissions, funding, and other Futures income
- emit automatic fee-aware 24-hour performance reports
- configure Discord, Redis, MongoDB, and logs through environment variables
- make AI review tolerate providers returning null response content
- document strategy ownership, Testnet rollout, EC2 rollback, accounting, and promotion procedures

## Why

Orbit could execute trades but lacked a closed performance-feedback loop and an independent risk boundary. Its production strategies were also loaded from a separate private repository, causing public CI authentication failures and allowing runtime/version drift between execution and signal code.

Orbit-Strategies is now a legacy research archive. Production signals, risk decisions, orders, and resulting performance all map to one Orbit commit.

## Impact

Paper mode is the safe default. EC2 must explicitly select Testnet or guarded live mode. CI and deployment no longer require credentials for another repository.

## Validation

- GitHub Actions Unit Tests: passed
- GitHub Actions Static Checker: passed, including pylint and mypy
- 8 focused execution, risk, and performance tests passed locally
- all Python files parsed successfully
- configuration JSON and patch formatting validated
- no Testnet or live orders were submitted
