### PR TITLE
Use OpenAI for market intelligence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,13 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DB=0
 ORBIT_LOG_FILE=app.log
+
+# Market intelligence. OpenAI Responses API is the primary provider.
+OPENAI_API_KEY=
+OPENAI_MODEL=gpt-5.6-terra
+OPENAI_MAX_OUTPUT_TOKENS=2000
+
+# Optional fallback providers, used only if the primary provider fails.
+OPENROUTER_API_KEY=
+OPENROUTER_MODEL=openrouter/free
+GROQ_API_KEY=

--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,8 @@ ORBIT_LOG_FILE=app.log
 
 # Market intelligence. OpenAI Responses API is the primary provider.
 OPENAI_API_KEY=
+# Optional alternative: path to a provisioned Codex CLI auth.json file.
+OPENAI_AUTH_FILE=
 OPENAI_MODEL=gpt-5.6-terra
 OPENAI_MAX_OUTPUT_TOKENS=2000
 

--- a/.github/scripts/process_codex_review.py
+++ b/.github/scripts/process_codex_review.py
@@ -26,7 +26,10 @@ def _validate(data: Any) -> dict[str, Any]:
     if verdict == "PASS" and findings:
         raise ValueError("PASS cannot contain findings")
     if verdict == "FAIL" and not findings:
-        raise ValueError("FAIL must contain findings")
+        raise ValueError(
+            "Codex review did not complete: FAIL contained no actionable findings. "
+            f"Reviewer summary: {summary.strip()}"
+        )
 
     required = {"priority", "path", "line", "title", "body"}
     for index, finding in enumerate(findings, start=1):

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -36,6 +36,11 @@ jobs:
         with:
           node-version: "22"
 
+      - name: Install Codex sandbox dependency
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes bubblewrap
+
       - name: Install pinned Codex CLI
         run: npm install --global @openai/codex@0.147.0
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ mode is separately locked. See
 for accounting, risk policy, EC2 rollout, and strategy-promotion procedures.
 The strategy migration and ownership boundary are documented in
 [`docs/architecture/STRATEGY_CONSOLIDATION.md`](docs/architecture/STRATEGY_CONSOLIDATION.md).
+The OpenAI model choice, provider fallback order, and market-intelligence
+configuration are documented in
+[`docs/architecture/MARKET_INTELLIGENCE_LLM.md`](docs/architecture/MARKET_INTELLIGENCE_LLM.md).
 This command launches `BinanceAutomation`, the top-level trading automation controller found in `src/orbit/core/main.py`. It orchestrates three long-running daemon threads:
 
 1. **Signal Analysis** — aligns to 15-minute candle boundaries, generates and processes trading signals via `SignalAnalyzer`, and sleeps for 900 seconds (15 minutes) between cycles.

--- a/docs/architecture/MARKET_INTELLIGENCE_LLM.md
+++ b/docs/architecture/MARKET_INTELLIGENCE_LLM.md
@@ -1,0 +1,52 @@
+# Market-intelligence LLM
+
+Orbit uses the OpenAI Responses API as the primary inference path for Reddit,
+Twitter, news, and combined sentiment analysis.
+
+## Decision
+
+The runtime uses `gpt-5.6-terra` by default. It is a general-purpose production
+model that balances intelligence and cost. A Codex model or the Codex CLI is
+not used in the trading process because Codex is optimized for agentic software
+engineering rather than recurring market classification. OpenAI also recommends
+GPT-5.6 rather than the rolling ChatGPT `chat-latest` alias for production API
+usage.
+
+Official references:
+
+- [OpenAI model selection](https://developers.openai.com/api/docs/models)
+- [Chat Latest production recommendation](https://developers.openai.com/api/docs/models/chat-latest)
+- [Codex model specialization](https://developers.openai.com/api/docs/models/gpt-5.1-codex)
+
+## Provider order
+
+1. OpenAI Responses API (`OPENAI_API_KEY`)
+2. OpenRouter, when `OPENROUTER_API_KEY` is configured
+3. Groq, when `GROQ_API_KEY` is configured
+
+Providers are initialized without making a network request. Each analysis call
+tries providers in that fixed order and falls back only after an error or empty
+response. This prevents startup probes from consuming tokens or blocking the
+sentiment worker during application boot.
+
+## Configuration
+
+```dotenv
+OPENAI_API_KEY=...
+OPENAI_MODEL=gpt-5.6-terra
+OPENAI_MAX_OUTPUT_TOKENS=2000
+```
+
+`OPENAI_MODEL` is configurable so a model can be evaluated and promoted without
+a code deployment. `OPENAI_MAX_OUTPUT_TOKENS` bounds response cost and must be a
+positive integer. `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, and `GROQ_API_KEY`
+are optional resilience settings. Production should alert when a fallback is
+used because different providers may produce different sentiment distributions.
+
+## Operational boundary
+
+The model classifies and explains supplied market data; it does not place an
+order. Existing strategy, sentiment-filter, and risk controls remain responsible
+for trade decisions. Model changes should be evaluated against a fixed set of
+representative prompts before promotion, with attention to JSON validity,
+sentiment consistency, latency, and token cost.

--- a/docs/architecture/MARKET_INTELLIGENCE_LLM.md
+++ b/docs/architecture/MARKET_INTELLIGENCE_LLM.md
@@ -20,7 +20,7 @@ Official references:
 
 ## Provider order
 
-1. OpenAI Responses API (`OPENAI_API_KEY`)
+1. OpenAI Responses API (`OPENAI_API_KEY`, or a provisioned Codex `auth.json`)
 2. OpenRouter, when `OPENROUTER_API_KEY` is configured
 3. Groq, when `GROQ_API_KEY` is configured
 
@@ -33,13 +33,18 @@ sentiment worker during application boot.
 
 ```dotenv
 OPENAI_API_KEY=...
+# Alternative to OPENAI_API_KEY:
+OPENAI_AUTH_FILE=/run/secrets/codex/auth.json
 OPENAI_MODEL=gpt-5.6-terra
 OPENAI_MAX_OUTPUT_TOKENS=2000
 ```
 
 `OPENAI_MODEL` is configurable so a model can be evaluated and promoted without
 a code deployment. `OPENAI_MAX_OUTPUT_TOKENS` bounds response cost and must be a
-positive integer. `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, and `GROQ_API_KEY`
+positive integer. When both authentication methods are present, the API key is
+preferred. OAuth credentials are re-read before each call so replacing the
+provisioned file refreshes the running worker; the credential must never be
+committed to the repository. `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, and `GROQ_API_KEY`
 are optional resilience settings. Production should alert when a fallback is
 used because different providers may produce different sentiment distributions.
 

--- a/src/orbit/market_intelligence/llm/llm_endpoint.py
+++ b/src/orbit/market_intelligence/llm/llm_endpoint.py
@@ -10,7 +10,11 @@ from datetime import datetime
 from dotenv import load_dotenv
 
 from orbit.core.exception_manager import ExceptionManager
-from orbit.market_intelligence.llm.openai_client import OpenAIResponsesClient
+from orbit.market_intelligence.llm.openai_client import (
+    CodexOAuthResponsesClient,
+    OpenAIResponsesClient,
+    default_auth_file,
+)
 from orbit.market_intelligence.llm.openrouter_client import OpenRouterClient
 
 load_dotenv()
@@ -53,6 +57,9 @@ class LLM(ExceptionManager):
         if self.openai_llm is None and os.getenv("OPENAI_API_KEY"):
             self.openai_llm = OpenAIResponsesClient(model=OPENAI_MODEL)
             logger.info("OpenAI model '%s' configured as primary", OPENAI_MODEL)
+        elif self.openai_llm is None and default_auth_file().is_file():
+            self.openai_llm = CodexOAuthResponsesClient(model=OPENAI_MODEL)
+            logger.info("OpenAI model '%s' configured with Codex OAuth", OPENAI_MODEL)
 
         # ------------------------------------------------------------------
         # 2. OpenRouter (FALLBACK)
@@ -81,7 +88,8 @@ class LLM(ExceptionManager):
 
         if not any((self.openai_llm, self.openrouter_llm, self.groq_llm)):
             raise RuntimeError(
-                "No market-intelligence LLM configured. Set OPENAI_API_KEY "
+                "No market-intelligence LLM configured. Set OPENAI_API_KEY, "
+                "provide OPENAI_AUTH_FILE, "
                 "or configure an optional fallback provider."
             )
 

--- a/src/orbit/market_intelligence/llm/llm_endpoint.py
+++ b/src/orbit/market_intelligence/llm/llm_endpoint.py
@@ -50,6 +50,7 @@ class LLM(ExceptionManager):
         self.openai_llm = openai_client
         self.openrouter_llm = openrouter_client
         self.groq_llm = groq_client
+        self._groq_providers = [("Groq", groq_client)] if groq_client is not None else []
 
         # ------------------------------------------------------------------
         # 1. OpenAI Responses API (PRIMARY)
@@ -76,13 +77,15 @@ class LLM(ExceptionManager):
         if self.groq_llm is None and os.getenv("GROQ_API_KEY"):
             for model_name in GROQ_MODELS:
                 try:
-                    self.groq_llm = ChatGroq(
+                    candidate = ChatGroq(
                         model=model_name,
                         temperature=0,
                         timeout=30,
                     )
-                    logger.info("Groq model '%s' configured as final fallback", model_name)
-                    break
+                    self._groq_providers.append((f"Groq ({model_name})", candidate))
+                    if self.groq_llm is None:
+                        self.groq_llm = candidate
+                    logger.info("Groq model '%s' configured as a fallback", model_name)
                 except Exception as error:
                     logger.warning("Could not configure Groq model '%s': %s", model_name, error)
 
@@ -99,11 +102,11 @@ class LLM(ExceptionManager):
         logger.info("Invoking market-intelligence LLM with about %d words", prompt_token_length)
         self._track_token_usage(prompt_token_length)
 
-        providers = (
+        providers = [
             ("OpenAI", self.openai_llm),
             ("OpenRouter", self.openrouter_llm),
-            ("Groq", self.groq_llm),
-        )
+            *self._groq_providers,
+        ]
         last_error: Optional[Exception] = None
 
         for provider_name, provider in providers:

--- a/src/orbit/market_intelligence/llm/llm_endpoint.py
+++ b/src/orbit/market_intelligence/llm/llm_endpoint.py
@@ -1,16 +1,16 @@
-# Initialize LLM with fallback
+"""Provider routing for Orbit market intelligence."""
 
 import logging
 import os
-from typing import Optional
+from typing import Any, Optional
 
 from langchain_groq import ChatGroq
 import redis
 from datetime import datetime
 from dotenv import load_dotenv
-from langfuse.langchain import CallbackHandler
 
 from orbit.core.exception_manager import ExceptionManager
+from orbit.market_intelligence.llm.openai_client import OpenAIResponsesClient
 from orbit.market_intelligence.llm.openrouter_client import OpenRouterClient
 
 load_dotenv()
@@ -18,132 +18,100 @@ load_dotenv()
 # ---------------------------------------------------------------------------
 # Model configuration
 # ---------------------------------------------------------------------------
-OPENROUTER_MODEL = "openrouter/free"
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5.6-terra")
+OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "openrouter/free")
 GROQ_MODELS = ["openai/gpt-oss-120b", "llama-3.1-8b-instant", "gemma2-9b-it"]
 
 logger = logging.getLogger("Orbit")
 
-langfuse_handler = CallbackHandler()
-
 class LLM(ExceptionManager):
-    """LLM wrapper with Groq as primary and OpenRouter as fallback."""
+    """Use OpenAI first, with optional OpenRouter and Groq fallbacks."""
 
-    def __init__(self) -> None:
+    def __init__(
+        self,
+        openai_client: Optional[Any] = None,
+        openrouter_client: Optional[Any] = None,
+        groq_client: Optional[Any] = None,
+        redis_client: Optional[Any] = None,
+    ) -> None:
         super().__init__()
 
-        self.redis_client = redis.StrictRedis(
-            host="localhost", port=6379, db=0, decode_responses=True
+        self.redis_client = redis_client or redis.StrictRedis(
+            host=os.getenv("REDIS_HOST", "localhost"),
+            port=int(os.getenv("REDIS_PORT", "6379")),
+            db=int(os.getenv("REDIS_DB", "0")),
+            decode_responses=True,
         )
 
-        self.groq_llm = None
-        self.openrouter_llm = None
-
-        os.environ["GROQ_API_KEY"] = os.getenv("GROQ_API_KEY")
+        self.openai_llm = openai_client
+        self.openrouter_llm = openrouter_client
+        self.groq_llm = groq_client
 
         # ------------------------------------------------------------------
-        # 1. Initialize OpenRouter (PRIMARY) 
+        # 1. OpenAI Responses API (PRIMARY)
         # ------------------------------------------------------------------
-        try:
-            client = OpenRouterClient(
-                api_key=os.getenv("OPENROUTER_API_KEY"),
+        if self.openai_llm is None and os.getenv("OPENAI_API_KEY"):
+            self.openai_llm = OpenAIResponsesClient(model=OPENAI_MODEL)
+            logger.info("OpenAI model '%s' configured as primary", OPENAI_MODEL)
+
+        # ------------------------------------------------------------------
+        # 2. OpenRouter (FALLBACK)
+        # ------------------------------------------------------------------
+        if self.openrouter_llm is None and os.getenv("OPENROUTER_API_KEY"):
+            self.openrouter_llm = OpenRouterClient(
                 model=OPENROUTER_MODEL,
             )
-
-            client.invoke("Test")
-
-            logger.info(
-                f"OpenRouter model '{OPENROUTER_MODEL}' initialized successfully"
-            )
-
-            self.openrouter_llm = client
-
-        except Exception as e:
-            logger.exception(f"OpenRouter initialization failed")
-            self.handle_exception(
-                e,
-                context_description="OpenRouter LLM init failure",
-            )
+            logger.info("OpenRouter model '%s' configured as fallback", OPENROUTER_MODEL)
 
         # ------------------------------------------------------------------
-        # 2. Initialize Groq (FALLBACK)
+        # 3. Groq (LAST FALLBACK)
         # ------------------------------------------------------------------
-        for model_name in GROQ_MODELS:
-            try:
-                logger.info(f"Trying Groq model: {model_name}")
-                candidate = ChatGroq(
-                    model=model_name,
-                    temperature=0,
-                    timeout=30,
-                )
-                candidate.invoke("Test")
-                logger.info(f"Groq model '{model_name}' initialized successfully")
-                self.groq_llm = candidate
-                break
-            except Exception as e:
-                logger.error(f"Failed Groq model '{model_name}': {e}")
+        if self.groq_llm is None and os.getenv("GROQ_API_KEY"):
+            for model_name in GROQ_MODELS:
+                try:
+                    self.groq_llm = ChatGroq(
+                        model=model_name,
+                        temperature=0,
+                        timeout=30,
+                    )
+                    logger.info("Groq model '%s' configured as final fallback", model_name)
+                    break
+                except Exception as error:
+                    logger.warning("Could not configure Groq model '%s': %s", model_name, error)
 
-    
-    # -----------------------------------------------------------------------
-    # invoke
-    # -----------------------------------------------------------------------
+        if not any((self.openai_llm, self.openrouter_llm, self.groq_llm)):
+            raise RuntimeError(
+                "No market-intelligence LLM configured. Set OPENAI_API_KEY "
+                "or configure an optional fallback provider."
+            )
 
-    def invoke(self, prompt: str, use_groq: bool = False) -> Optional[str]:
-
-        assert self.groq_llm or self.openrouter_llm, "No LLM backend available"
-    
+    def invoke(self, prompt: str) -> str:
+        """Invoke providers in deterministic priority order."""
         prompt_token_length = len(prompt.split())
-        logger.info(f"Invoking LLM token length: {prompt_token_length}")
+        logger.info("Invoking market-intelligence LLM with about %d words", prompt_token_length)
         self._track_token_usage(prompt_token_length)
 
-        # ----------------------------------------------------------
-        # 1. Use GROQ as primary only if explicitly requested
-        # ----------------------------------------------------------
-        if use_groq and self.groq_llm:
+        providers = (
+            ("OpenAI", self.openai_llm),
+            ("OpenRouter", self.openrouter_llm),
+            ("Groq", self.groq_llm),
+        )
+        last_error: Optional[Exception] = None
+
+        for provider_name, provider in providers:
+            if provider is None:
+                continue
             try:
-                response = self.groq_llm.invoke(
-                            prompt,
-                            config={
-                            "callbacks": [langfuse_handler]
-                            }
-                        )
-                return response.content if hasattr(response, "content") else response
+                response = provider.invoke(prompt)
+                content = response.content if hasattr(response, "content") else response
+                if content and str(content).strip():
+                    return str(content).strip()
+                raise RuntimeError(f"{provider_name} returned an empty response")
+            except Exception as error:
+                last_error = error
+                logger.exception("%s market-intelligence provider failed", provider_name)
 
-            except Exception:
-                logger.exception("Groq failed, falling back to OpenRouter")
-
-                if self.openrouter_llm:
-                    try:
-                        return self.openrouter_llm.invoke(prompt)
-                    except Exception as fallback_error:
-                        self.handle_exception(
-                            fallback_error,
-                            context_description="OpenRouter fallback failure",
-                        )
-
-        # ----------------------------------------------------------
-        # 1. Try OpenRouter first
-        # ----------------------------------------------------------
-        if self.openrouter_llm:
-            try:
-                return self.openrouter_llm.invoke(prompt)
-            except Exception:
-                logger.exception(f"OpenRouter failed, falling back to Groq")
-
-        
-        # ----------------------------------------------------------
-        # 2. Fallback → GROQ
-        # ----------------------------------------------------------
-        if self.groq_llm:
-            try:
-                response = self.groq_llm.invoke(prompt)
-                return response.content
-            except Exception as e:
-                self.handle_exception(
-                    e,
-                    context_description="Groq LLM fallback failure",
-                )
-
-        return None
+        raise RuntimeError("All configured market-intelligence providers failed") from last_error
 
     # -----------------------------------------------------------------------
     # Helpers

--- a/src/orbit/market_intelligence/llm/openai_client.py
+++ b/src/orbit/market_intelligence/llm/openai_client.py
@@ -1,0 +1,59 @@
+"""OpenAI Responses API client for Orbit market intelligence."""
+
+import logging
+import os
+from typing import Optional
+
+from openai import OpenAI
+
+logger = logging.getLogger("Orbit")
+
+DEFAULT_OPENAI_MODEL = "gpt-5.6-terra"
+DEFAULT_MAX_OUTPUT_TOKENS = 2_000
+DEFAULT_INSTRUCTIONS = (
+    "You are Orbit's market-intelligence analyst. Follow the requested output "
+    "schema exactly. When JSON is requested, return only valid JSON without "
+    "Markdown fences or additional commentary. Do not invent market data."
+)
+
+
+class OpenAIResponsesClient:
+    """Small adapter exposing the ``invoke(prompt)`` interface used by Orbit."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        model: Optional[str] = None,
+        timeout: float = 60.0,
+        max_output_tokens: Optional[int] = None,
+        client: Optional[OpenAI] = None,
+    ) -> None:
+        resolved_api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if client is None and not resolved_api_key:
+            raise ValueError("OPENAI_API_KEY is required for the OpenAI provider")
+
+        self.model = model or os.getenv("OPENAI_MODEL", DEFAULT_OPENAI_MODEL)
+        self.max_output_tokens = max_output_tokens or int(
+            os.getenv("OPENAI_MAX_OUTPUT_TOKENS", str(DEFAULT_MAX_OUTPUT_TOKENS))
+        )
+        if self.max_output_tokens < 1:
+            raise ValueError("OPENAI_MAX_OUTPUT_TOKENS must be positive")
+        self.client = client or OpenAI(api_key=resolved_api_key, timeout=timeout)
+
+    def invoke(self, prompt: str) -> str:
+        """Generate a market-intelligence response through the Responses API."""
+        if not prompt or not prompt.strip():
+            raise ValueError("prompt must not be empty")
+
+        response = self.client.responses.create(
+            model=self.model,
+            instructions=DEFAULT_INSTRUCTIONS,
+            input=prompt,
+            max_output_tokens=self.max_output_tokens,
+        )
+        output_text = response.output_text
+        if not output_text or not output_text.strip():
+            raise RuntimeError("OpenAI returned an empty response")
+
+        logger.info("OpenAI market-intelligence response generated with %s", self.model)
+        return output_text.strip()

--- a/src/orbit/market_intelligence/llm/openai_client.py
+++ b/src/orbit/market_intelligence/llm/openai_client.py
@@ -56,6 +56,11 @@ class OpenAIResponsesClient:
             input=prompt,
             max_output_tokens=self.max_output_tokens,
         )
+        if response.status != "completed":
+            details = getattr(response, "incomplete_details", None)
+            raise RuntimeError(
+                f"OpenAI response ended with status {response.status!r}: {details}"
+            )
         output_text = response.output_text
         if not output_text or not output_text.strip():
             raise RuntimeError("OpenAI returned an empty response")

--- a/src/orbit/market_intelligence/llm/openai_client.py
+++ b/src/orbit/market_intelligence/llm/openai_client.py
@@ -1,8 +1,12 @@
-"""OpenAI Responses API client for Orbit market intelligence."""
+"""OpenAI Responses API clients for Orbit market intelligence."""
 
+import json
 import logging
 import os
-from typing import Optional
+from pathlib import Path
+import urllib.error
+import urllib.request
+from typing import Any, Callable, Optional
 
 from openai import OpenAI
 
@@ -15,6 +19,7 @@ DEFAULT_INSTRUCTIONS = (
     "schema exactly. When JSON is requested, return only valid JSON without "
     "Markdown fences or additional commentary. Do not invent market data."
 )
+DEFAULT_CODEX_RESPONSES_URL = "https://chatgpt.com/backend-api/codex/responses"
 
 
 class OpenAIResponsesClient:
@@ -57,3 +62,130 @@ class OpenAIResponsesClient:
 
         logger.info("OpenAI market-intelligence response generated with %s", self.model)
         return output_text.strip()
+
+
+def default_auth_file() -> Path:
+    """Return the Codex credential file location without requiring it to exist."""
+    configured_file = os.getenv("OPENAI_AUTH_FILE")
+    if configured_file:
+        return Path(configured_file).expanduser()
+
+    codex_home = os.getenv("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home).expanduser() / "auth.json"
+    return Path.home() / ".codex" / "auth.json"
+
+
+class CodexOAuthResponsesClient:
+    """Responses adapter authenticated with a Codex CLI ``auth.json`` file.
+
+    This path is useful in environments where the Codex login session is
+    provisioned as a file instead of an API key. The file is re-read for every
+    request so an externally refreshed login is picked up without a restart.
+    """
+
+    def __init__(
+        self,
+        auth_file: Optional[os.PathLike[str] | str] = None,
+        model: Optional[str] = None,
+        timeout: float = 60.0,
+        max_output_tokens: Optional[int] = None,
+        endpoint: Optional[str] = None,
+        urlopen: Callable[..., Any] = urllib.request.urlopen,
+    ) -> None:
+        self.auth_file = Path(auth_file).expanduser() if auth_file else default_auth_file()
+        self.model = model or os.getenv("OPENAI_MODEL", DEFAULT_OPENAI_MODEL)
+        self.timeout = timeout
+        self.max_output_tokens = max_output_tokens or int(
+            os.getenv("OPENAI_MAX_OUTPUT_TOKENS", str(DEFAULT_MAX_OUTPUT_TOKENS))
+        )
+        if self.max_output_tokens < 1:
+            raise ValueError("OPENAI_MAX_OUTPUT_TOKENS must be positive")
+        self.endpoint = endpoint or os.getenv(
+            "OPENAI_CODEX_RESPONSES_URL", DEFAULT_CODEX_RESPONSES_URL
+        )
+        self._urlopen = urlopen
+
+    def _credentials(self) -> tuple[str, Optional[str]]:
+        try:
+            auth = json.loads(self.auth_file.read_text(encoding="utf-8"))
+        except FileNotFoundError as error:
+            raise RuntimeError(f"Codex auth file not found: {self.auth_file}") from error
+        except (OSError, json.JSONDecodeError) as error:
+            raise RuntimeError(f"Could not read Codex auth file: {self.auth_file}") from error
+
+        auth = auth if isinstance(auth, dict) else {}
+        tokens = auth.get("tokens")
+        tokens = tokens if isinstance(tokens, dict) else {}
+        access_token = tokens.get("access_token") or auth.get("access_token")
+        account_id = tokens.get("account_id") or auth.get("account_id")
+        if not isinstance(access_token, str) or not access_token:
+            raise RuntimeError("Codex auth.json does not contain an access token")
+        return access_token, account_id if isinstance(account_id, str) else None
+
+    def invoke(self, prompt: str) -> str:
+        """Stream one sentiment-analysis response and return its complete text."""
+        if not prompt or not prompt.strip():
+            raise ValueError("prompt must not be empty")
+
+        access_token, account_id = self._credentials()
+        payload = json.dumps(
+            {
+                "model": self.model,
+                "instructions": DEFAULT_INSTRUCTIONS,
+                "input": prompt,
+                "max_output_tokens": self.max_output_tokens,
+                "stream": True,
+                "store": False,
+            }
+        ).encode("utf-8")
+        headers = {
+            "Authorization": f"Bearer {access_token}",
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream",
+            "OpenAI-Beta": "responses=experimental",
+            "originator": "orbit",
+        }
+        if account_id:
+            headers["ChatGPT-Account-Id"] = account_id
+
+        request = urllib.request.Request(
+            self.endpoint, data=payload, headers=headers, method="POST"
+        )
+        assistant_text: list[str] = []
+        completed = False
+        try:
+            with self._urlopen(request, timeout=self.timeout) as response:
+                for raw_line in response:
+                    line = raw_line.decode("utf-8", errors="replace").strip()
+                    if not line.startswith("data: "):
+                        continue
+                    data = line.removeprefix("data: ")
+                    if data == "[DONE]":
+                        break
+                    event = json.loads(data)
+                    event_type = event.get("type")
+                    if event_type == "response.output_text.delta":
+                        delta = event.get("delta", "")
+                        if isinstance(delta, str):
+                            assistant_text.append(delta)
+                    elif event_type == "response.completed":
+                        completed = True
+                    elif event_type == "error":
+                        raise RuntimeError(f"OpenAI streaming error: {event}")
+        except urllib.error.HTTPError as error:
+            details = error.read().decode("utf-8", errors="replace")
+            hint = " Run `codex login` to refresh auth.json." if error.code == 401 else ""
+            raise RuntimeError(f"OpenAI HTTP {error.code}: {details}.{hint}") from error
+        except urllib.error.URLError as error:
+            raise RuntimeError(f"OpenAI request failed: {error.reason}") from error
+        except json.JSONDecodeError as error:
+            raise RuntimeError("OpenAI returned an invalid streaming event") from error
+
+        output_text = "".join(assistant_text).strip()
+        if not completed:
+            raise RuntimeError("OpenAI stream ended before response.completed")
+        if not output_text:
+            raise RuntimeError("OpenAI returned an empty response")
+        logger.info("OpenAI OAuth response generated with %s", self.model)
+        return output_text

--- a/src/orbit/market_intelligence/sentimental_workflow.py
+++ b/src/orbit/market_intelligence/sentimental_workflow.py
@@ -375,7 +375,7 @@ class SentimentWorkflow(ExceptionManager):
         )
 
         try:
-            content = self.llm.invoke(prompt, use_groq=True)
+            content = self.llm.invoke(prompt)
             return str(content).strip()
         except Exception as e:
             logger.exception("Reasoning generation failed")
@@ -719,7 +719,7 @@ class SentimentWorkflow(ExceptionManager):
         )
 
         try:
-            content = self.llm.invoke(prompt, use_groq=True)
+            content = self.llm.invoke(prompt)
             content = str(content).strip()
             blend_sentiment: Dict[str, Any] = extract_json(content)  # validate JSON format
             return Sentiment(**blend_sentiment)

--- a/src/orbit/market_intelligence/utils/utils.py
+++ b/src/orbit/market_intelligence/utils/utils.py
@@ -1,6 +1,5 @@
 
 
-import os
 import logging
 import time
 import requests
@@ -10,13 +9,9 @@ from functools import lru_cache
 from typing import Optional
 from enum import Enum
 from pydantic import BaseModel, Field, field_validator
-from orbit.utils.utils import require_env
 from dotenv import load_dotenv
 
 load_dotenv()  # Load environment variables from .env file
-
-os.environ["GROQ_API_KEY"] = require_env("GROQ_API_KEY")
-GROQ_MODEL = "openai/gpt-oss-120b"
 
 logger = logging.getLogger("Orbit")
 

--- a/tests/test_market_intelligence_llm.py
+++ b/tests/test_market_intelligence_llm.py
@@ -1,3 +1,4 @@
+import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -8,6 +9,7 @@ from orbit.market_intelligence.llm.openai_client import (
     DEFAULT_INSTRUCTIONS,
     DEFAULT_MAX_OUTPUT_TOKENS,
     DEFAULT_OPENAI_MODEL,
+    CodexOAuthResponsesClient,
     OpenAIResponsesClient,
 )
 
@@ -47,6 +49,52 @@ def test_openai_client_rejects_empty_output() -> None:
         client.invoke("Classify this market")
 
 
+def test_codex_oauth_client_streams_responses(tmp_path) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps({"tokens": {"access_token": "secret", "account_id": "acct"}}),
+        encoding="utf-8",
+    )
+
+    class StreamingResponse:
+        def __enter__(self):
+            return iter(
+                [
+                    b'data: {"type":"response.output_text.delta","delta":"BULL"}\n',
+                    b'data: {"type":"response.output_text.delta","delta":"ISH"}\n',
+                    b'data: {"type":"response.completed"}\n',
+                    b"data: [DONE]\n",
+                ]
+            )
+
+        def __exit__(self, *_args):
+            return False
+
+    requests = []
+
+    def urlopen(request, timeout):
+        requests.append((request, timeout))
+        return StreamingResponse()
+
+    client = CodexOAuthResponsesClient(auth_file=auth_file, urlopen=urlopen)
+
+    assert client.invoke("Classify this market") == "BULLISH"
+    request, timeout = requests[0]
+    assert timeout == 60.0
+    assert request.get_header("Authorization") == "Bearer secret"
+    assert request.get_header("Chatgpt-account-id") == "acct"
+    assert json.loads(request.data)["stream"] is True
+
+
+def test_codex_oauth_client_requires_access_token(tmp_path) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text("{}", encoding="utf-8")
+    client = CodexOAuthResponsesClient(auth_file=auth_file)
+
+    with pytest.raises(RuntimeError, match="access token"):
+        client.invoke("Classify this market")
+
+
 def test_llm_prefers_openai_without_startup_request() -> None:
     openai_client = MagicMock()
     openai_client.invoke.return_value = "primary"
@@ -81,9 +129,13 @@ def test_llm_falls_back_when_openai_fails() -> None:
     openrouter_client.invoke.assert_called_once_with("market prompt")
 
 
-def test_llm_requires_at_least_one_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_llm_requires_at_least_one_provider(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
     for variable in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "GROQ_API_KEY"):
         monkeypatch.delenv(variable, raising=False)
+    monkeypatch.delenv("OPENAI_AUTH_FILE", raising=False)
+    monkeypatch.setenv("CODEX_HOME", str(tmp_path))
 
     with pytest.raises(RuntimeError, match="No market-intelligence LLM configured"):
         LLM(redis_client=_redis_mock())

--- a/tests/test_market_intelligence_llm.py
+++ b/tests/test_market_intelligence_llm.py
@@ -25,7 +25,9 @@ def _redis_mock() -> MagicMock:
 def test_openai_client_uses_responses_api() -> None:
     sdk_client = MagicMock()
     sdk_client.responses.create.return_value = SimpleNamespace(
-        output_text='{"sentiment":"NEUTRAL"}'
+        status="completed",
+        incomplete_details=None,
+        output_text='{"sentiment":"NEUTRAL"}',
     )
     client = OpenAIResponsesClient(client=sdk_client)
 
@@ -42,10 +44,25 @@ def test_openai_client_uses_responses_api() -> None:
 
 def test_openai_client_rejects_empty_output() -> None:
     sdk_client = MagicMock()
-    sdk_client.responses.create.return_value = SimpleNamespace(output_text=" ")
+    sdk_client.responses.create.return_value = SimpleNamespace(
+        status="completed", incomplete_details=None, output_text=" "
+    )
     client = OpenAIResponsesClient(client=sdk_client)
 
     with pytest.raises(RuntimeError, match="empty response"):
+        client.invoke("Classify this market")
+
+
+def test_openai_client_rejects_nonempty_incomplete_output() -> None:
+    sdk_client = MagicMock()
+    sdk_client.responses.create.return_value = SimpleNamespace(
+        status="incomplete",
+        incomplete_details=SimpleNamespace(reason="max_output_tokens"),
+        output_text='{"sentiment":"BULLISH"',
+    )
+    client = OpenAIResponsesClient(client=sdk_client)
+
+    with pytest.raises(RuntimeError, match="status 'incomplete'"):
         client.invoke("Classify this market")
 
 
@@ -127,6 +144,37 @@ def test_llm_falls_back_when_openai_fails() -> None:
 
     assert llm.invoke("market prompt") == "fallback"
     openrouter_client.invoke.assert_called_once_with("market prompt")
+
+
+def test_llm_tries_each_configured_groq_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GROQ_API_KEY", "test-key")
+    first = MagicMock()
+    first.invoke.side_effect = RuntimeError("model unavailable")
+    second = MagicMock()
+    second.invoke.return_value = SimpleNamespace(content="second model")
+    third = MagicMock()
+    candidates = iter((first, second, third))
+    monkeypatch.setattr(
+        "orbit.market_intelligence.llm.llm_endpoint.ChatGroq",
+        lambda **_kwargs: next(candidates),
+    )
+
+    openai_client = MagicMock()
+    openai_client.invoke.side_effect = RuntimeError("OpenAI unavailable")
+    openrouter_client = MagicMock()
+    openrouter_client.invoke.side_effect = RuntimeError("OpenRouter unavailable")
+    llm = LLM(
+        openai_client=openai_client,
+        openrouter_client=openrouter_client,
+        redis_client=_redis_mock(),
+    )
+
+    assert llm.invoke("market prompt") == "second model"
+    first.invoke.assert_called_once_with("market prompt")
+    second.invoke.assert_called_once_with("market prompt")
+    third.invoke.assert_not_called()
 
 
 def test_llm_requires_at_least_one_provider(

--- a/tests/test_market_intelligence_llm.py
+++ b/tests/test_market_intelligence_llm.py
@@ -1,0 +1,89 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from orbit.market_intelligence.llm.llm_endpoint import LLM
+from orbit.market_intelligence.llm.openai_client import (
+    DEFAULT_INSTRUCTIONS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_OPENAI_MODEL,
+    OpenAIResponsesClient,
+)
+
+
+def _redis_mock() -> MagicMock:
+    redis_client = MagicMock()
+    redis_client.exists.return_value = True
+    redis_client.ttl.return_value = 100
+    redis_client.get.return_value = "10"
+    return redis_client
+
+
+def test_openai_client_uses_responses_api() -> None:
+    sdk_client = MagicMock()
+    sdk_client.responses.create.return_value = SimpleNamespace(
+        output_text='{"sentiment":"NEUTRAL"}'
+    )
+    client = OpenAIResponsesClient(client=sdk_client)
+
+    result = client.invoke("Classify this market")
+
+    assert result == '{"sentiment":"NEUTRAL"}'
+    sdk_client.responses.create.assert_called_once_with(
+        model=DEFAULT_OPENAI_MODEL,
+        instructions=DEFAULT_INSTRUCTIONS,
+        input="Classify this market",
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
+    )
+
+
+def test_openai_client_rejects_empty_output() -> None:
+    sdk_client = MagicMock()
+    sdk_client.responses.create.return_value = SimpleNamespace(output_text=" ")
+    client = OpenAIResponsesClient(client=sdk_client)
+
+    with pytest.raises(RuntimeError, match="empty response"):
+        client.invoke("Classify this market")
+
+
+def test_llm_prefers_openai_without_startup_request() -> None:
+    openai_client = MagicMock()
+    openai_client.invoke.return_value = "primary"
+    fallback = MagicMock()
+
+    llm = LLM(
+        openai_client=openai_client,
+        openrouter_client=fallback,
+        groq_client=fallback,
+        redis_client=_redis_mock(),
+    )
+
+    openai_client.invoke.assert_not_called()
+    assert llm.invoke("market prompt") == "primary"
+    fallback.invoke.assert_not_called()
+
+
+def test_llm_falls_back_when_openai_fails() -> None:
+    openai_client = MagicMock()
+    openai_client.invoke.side_effect = RuntimeError("OpenAI unavailable")
+    openrouter_client = MagicMock()
+    openrouter_client.invoke.return_value = "fallback"
+
+    llm = LLM(
+        openai_client=openai_client,
+        openrouter_client=openrouter_client,
+        groq_client=MagicMock(),
+        redis_client=_redis_mock(),
+    )
+
+    assert llm.invoke("market prompt") == "fallback"
+    openrouter_client.invoke.assert_called_once_with("market prompt")
+
+
+def test_llm_requires_at_least_one_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    for variable in ("OPENAI_API_KEY", "OPENROUTER_API_KEY", "GROQ_API_KEY"):
+        monkeypatch.delenv(variable, raising=False)
+
+    with pytest.raises(RuntimeError, match="No market-intelligence LLM configured"):
+        LLM(redis_client=_redis_mock())

--- a/tests/test_process_codex_review.py
+++ b/tests/test_process_codex_review.py
@@ -54,6 +54,17 @@ class TestCodexReviewProcessing(unittest.TestCase):
                 }
             )
 
+    def test_incomplete_failure_has_actionable_error(self):
+        with self.assertRaisesRegex(ValueError, "Codex review did not complete") as error:
+            MODULE._validate(
+                {
+                    "verdict": "FAIL",
+                    "summary": "Sandbox initialization failed.",
+                    "findings": [],
+                }
+            )
+        self.assertIn("Sandbox initialization failed", str(error.exception))
+
     def test_parent_path_is_rejected(self):
         with self.assertRaises(ValueError):
             MODULE._validate(


### PR DESCRIPTION
## Summary

- add a direct OpenAI Responses API client for market-intelligence inference
- use `gpt-5.6-terra` by default, with `OPENAI_MODEL` as a deployment override
- route providers deterministically as OpenAI → OpenRouter → Groq
- remove boot-time provider probes and the import-time Groq credential requirement
- bound OpenAI responses with `OPENAI_MAX_OUTPUT_TOKENS`
- add provider routing tests and deployment documentation

## Decision

Orbit should use a general-purpose OpenAI API model rather than invoking Codex inside the trading runtime. Codex models are optimized for agentic coding, while OpenAI recommends GPT-5.6 for production API workloads. Terra provides the balanced quality/cost option for recurring sentiment analysis.

Official references:

- https://developers.openai.com/api/docs/models
- https://developers.openai.com/api/docs/models/chat-latest
- https://developers.openai.com/api/docs/models/gpt-5.1-codex

## Runtime impact

The sentiment worker now uses `OPENAI_API_KEY` through the Responses API. Existing sentiment combination, strategy filters, and risk/order controls are unchanged. Optional OpenRouter and Groq credentials retain failover capability.

Provider construction no longer sends a paid test prompt at application startup. If no provider is configured, startup fails with a clear configuration error instead of failing indirectly during analysis.

## Deployment

Configure the EC2 runtime with:

```dotenv
OPENAI_API_KEY=...
OPENAI_MODEL=gpt-5.6-terra
OPENAI_MAX_OUTPUT_TOKENS=2000
```

The API key must remain in the deployment secret store and must not be committed.

## Validation

- `pytest -q -p no:cacheprovider` — 68 passed
- `pylint --disable=W,R,C,I --ignore=.venv .`
- `mypy src/orbit/market_intelligence/*.py`
- `ruff check src config .github/scripts tests --select F401,F821,F841`
- `git diff --check`
