### PR TITLE
Simplify logger output format

### DIFF
--- a/config/logging_config.yaml
+++ b/config/logging_config.yaml
@@ -3,8 +3,7 @@ version: 1
 formatters:
   colored:
     class: colorlog.ColoredFormatter
-    format: "%(log_color)s%(asctime)s [%(levelname)s] %(filename)s:%(lineno)d - %(message)s"
-    datefmt: "%Y-%m-%d %H:%M:%S"
+    format: "%(log_color)s%(filename)s | %(levelname)s | %(message)s"
     log_colors:
       DEBUG:    cyan
       INFO:     green
@@ -13,7 +12,7 @@ formatters:
       CRITICAL: bold_red
 
   detailed:
-    format: "%(asctime)s [%(levelname)s] %(filename)s:%(lineno)d - %(message)s"
+    format: "%(filename)s | %(levelname)s | %(message)s"
 
 handlers:
   console:

--- a/config/logging_config.yaml
+++ b/config/logging_config.yaml
@@ -3,7 +3,7 @@ version: 1
 formatters:
   colored:
     class: colorlog.ColoredFormatter
-    format: "%(log_color)s%(filename)s | %(levelname)s | %(message)s"
+    format: "%(log_color)s%(filename)s:%(lineno)d | %(levelname)s | %(message)s"
     log_colors:
       DEBUG:    cyan
       INFO:     green
@@ -12,7 +12,7 @@ formatters:
       CRITICAL: bold_red
 
   detailed:
-    format: "%(filename)s | %(levelname)s | %(message)s"
+    format: "%(filename)s:%(lineno)d | %(levelname)s | %(message)s"
 
 handlers:
   console:


### PR DESCRIPTION
## Summary

- format console logs as `filename | log-level | msg`
- apply the same format to file logs
- remove timestamps and line numbers from logger output

## Validation

- rendered a representative Python `LogRecord` and verified `worker.py | INFO | ready`
- `git diff --check`