### PR TITLE
Fix Codex OAuth input payload

### DIFF
--- a/src/orbit/market_intelligence/llm/openai_client.py
+++ b/src/orbit/market_intelligence/llm/openai_client.py
@@ -138,7 +138,12 @@ class CodexOAuthResponsesClient:
             {
                 "model": self.model,
                 "instructions": DEFAULT_INSTRUCTIONS,
-                "input": prompt,
+                "input": [
+                    {
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": prompt}],
+                    }
+                ],
                 "max_output_tokens": self.max_output_tokens,
                 "stream": True,
                 "store": False,

--- a/tests/test_market_intelligence_llm.py
+++ b/tests/test_market_intelligence_llm.py
@@ -100,7 +100,16 @@ def test_codex_oauth_client_streams_responses(tmp_path) -> None:
     assert timeout == 60.0
     assert request.get_header("Authorization") == "Bearer secret"
     assert request.get_header("Chatgpt-account-id") == "acct"
-    assert json.loads(request.data)["stream"] is True
+    payload = json.loads(request.data)
+    assert payload["stream"] is True
+    assert payload["input"] == [
+        {
+            "role": "user",
+            "content": [
+                {"type": "input_text", "text": "Classify this market"}
+            ],
+        }
+    ]
 
 
 def test_codex_oauth_client_requires_access_token(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- send Codex OAuth Responses input as a list of user message items
- encode the prompt in an `input_text` content block
- assert the complete serialized input structure in the regression test

## Root cause

The Codex backend rejects scalar `input` values with HTTP 400 (`Input must be a list`), causing every OAuth request to fall through to OpenRouter.

## Impact

OAuth-backed OpenAI sentiment requests can now reach the model instead of incurring a failed request and fallback delay.

## Validation

- Python compilation passed
- `git diff --check` passed
- full pytest execution was unavailable locally because pytest is not installed