### PR TITLE
Remove unsupported Codex response parameter

### DIFF
--- a/src/orbit/market_intelligence/llm/openai_client.py
+++ b/src/orbit/market_intelligence/llm/openai_client.py
@@ -144,7 +144,6 @@ class CodexOAuthResponsesClient:
                         "content": [{"type": "input_text", "text": prompt}],
                     }
                 ],
-                "max_output_tokens": self.max_output_tokens,
                 "stream": True,
                 "store": False,
             }

--- a/tests/test_market_intelligence_llm.py
+++ b/tests/test_market_intelligence_llm.py
@@ -101,15 +101,20 @@ def test_codex_oauth_client_streams_responses(tmp_path) -> None:
     assert request.get_header("Authorization") == "Bearer secret"
     assert request.get_header("Chatgpt-account-id") == "acct"
     payload = json.loads(request.data)
-    assert payload["stream"] is True
-    assert payload["input"] == [
-        {
-            "role": "user",
-            "content": [
-                {"type": "input_text", "text": "Classify this market"}
-            ],
-        }
-    ]
+    assert payload == {
+        "model": DEFAULT_OPENAI_MODEL,
+        "instructions": DEFAULT_INSTRUCTIONS,
+        "input": [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "input_text", "text": "Classify this market"}
+                ],
+            }
+        ],
+        "stream": True,
+        "store": False,
+    }
 
 
 def test_codex_oauth_client_requires_access_token(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- remove `max_output_tokens` from the Codex OAuth backend request
- keep output limiting on the supported public Responses API path
- assert the complete OAuth payload so unsupported fields cannot silently return

## Root cause

The Codex backend does not accept the public Responses API `max_output_tokens` request parameter and returned HTTP 400 after the input-list issue was fixed.

## Impact

OAuth-backed OpenAI sentiment calls can proceed without immediately falling through to OpenRouter and adding avoidable latency.

## Validation

- Python compilation passed
- `git diff --check` passed
- the previous payload tests passed in CI; this follow-up tightens the payload assertion