### PR TITLE
Migrate hourly sentiment to ChatGPT web search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,7 +30,7 @@ ORBIT_LOG_FILE=app.log
 OPENAI_API_KEY=
 # Optional alternative: path to a provisioned Codex CLI auth.json file.
 OPENAI_AUTH_FILE=
-OPENAI_MODEL=gpt-5.6-terra
+OPENAI_MODEL=gpt-5.6-luna
 OPENAI_MAX_OUTPUT_TOKENS=2000
 OPENAI_WEB_SEARCH_TIMEOUT=300
 # Legacy RSS/Reddit/Twitter polling is off; hourly ChatGPT web search is primary.

--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,9 @@ OPENAI_API_KEY=
 OPENAI_AUTH_FILE=
 OPENAI_MODEL=gpt-5.6-terra
 OPENAI_MAX_OUTPUT_TOKENS=2000
+OPENAI_WEB_SEARCH_TIMEOUT=300
+# Legacy RSS/Reddit/Twitter polling is off; hourly ChatGPT web search is primary.
+ORBIT_LEGACY_SENTIMENT_UPDATES=false
 
 # Optional fallback providers, used only if the primary provider fails.
 OPENROUTER_API_KEY=

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 Orbit is an AI-based trading framework that bridges research experimentation and production trading. It integrates classical strategies, machine learning models, and reinforcement learning experiments into a modular, automation-friendly architecture for both market intelligence and trading operations.
 
 ### Key Features
-- **Market Intelligence:** Harness Reddit and news sentiment data for actionable insights using LLM-powered analysis.
+- **Market Intelligence:** Run hourly, web-grounded financial and crypto-futures sentiment analysis with validated sources.
 - **Automated Trading:** Execute and monitor Binance Futures trades with precision, including SL/TP lifecycle management.
 - **Modular Design:** Easily integrate custom strategies via a lazy-loading strategy registry.
 - **Self-contained Strategies:** Production BTC, ETH, and BCH strategies are versioned and deployed with Orbit; no private runtime repository is required.

--- a/docs/architecture/MARKET_INTELLIGENCE_LLM.md
+++ b/docs/architecture/MARKET_INTELLIGENCE_LLM.md
@@ -6,8 +6,8 @@ futures positioning without placing orders or bypassing trading controls.
 
 ## Decision
 
-The runtime uses `gpt-5.6-terra` by default. It is a general-purpose production
-model that balances intelligence and cost. A Codex model or the Codex CLI is
+The runtime uses `gpt-5.6-luna` by default. It is a lower-cost model that passed
+the live, sourced hourly sentiment schema check. A Codex model or the Codex CLI is
 not used in the trading process because Codex is optimized for agentic software
 engineering rather than recurring market classification. OpenAI also recommends
 GPT-5.6 rather than the rolling ChatGPT `chat-latest` alias for production API
@@ -42,7 +42,7 @@ continues to apply to legacy non-web calls.
 OPENAI_API_KEY=...
 # Alternative to OPENAI_API_KEY:
 OPENAI_AUTH_FILE=/run/secrets/codex/auth.json
-OPENAI_MODEL=gpt-5.6-terra
+OPENAI_MODEL=gpt-5.6-luna
 OPENAI_MAX_OUTPUT_TOKENS=2000
 OPENAI_WEB_SEARCH_TIMEOUT=300
 ORBIT_LEGACY_SENTIMENT_UPDATES=false

--- a/docs/architecture/MARKET_INTELLIGENCE_LLM.md
+++ b/docs/architecture/MARKET_INTELLIGENCE_LLM.md
@@ -1,7 +1,8 @@
 # Market-intelligence LLM
 
-Orbit uses the OpenAI Responses API as the primary inference path for Reddit,
-Twitter, news, and combined sentiment analysis.
+Orbit uses one live, web-grounded OpenAI Responses analysis as the primary
+hourly market-intelligence path. It covers global finance, cryptocurrency, and
+futures positioning without placing orders or bypassing trading controls.
 
 ## Decision
 
@@ -29,6 +30,12 @@ tries providers in that fixed order and falls back only after an error or empty
 response. This prevents startup probes from consuming tokens or blocking the
 sentiment worker during application boot.
 
+The hourly web-search call is intentionally OpenAI-only because OpenRouter and
+Groq fallbacks cannot guarantee live web grounding. If it fails, the hourly run
+fails closed: the existing Redis sentiment is preserved and the scheduler
+retries rather than publishing an ungrounded replacement. Provider fallback
+continues to apply to legacy non-web calls.
+
 ## Configuration
 
 ```dotenv
@@ -37,6 +44,8 @@ OPENAI_API_KEY=...
 OPENAI_AUTH_FILE=/run/secrets/codex/auth.json
 OPENAI_MODEL=gpt-5.6-terra
 OPENAI_MAX_OUTPUT_TOKENS=2000
+OPENAI_WEB_SEARCH_TIMEOUT=300
+ORBIT_LEGACY_SENTIMENT_UPDATES=false
 ```
 
 `OPENAI_MODEL` is configurable so a model can be evaluated and promoted without
@@ -47,6 +56,21 @@ provisioned file refreshes the running worker; the credential must never be
 committed to the repository. `OPENROUTER_API_KEY`, `OPENROUTER_MODEL`, and `GROQ_API_KEY`
 are optional resilience settings. Production should alert when a fallback is
 used because different providers may produce different sentiment distributions.
+
+## Hourly web-search flow
+
+Once per hour, `Croner.run_once()` asks `SentimentWorkflow` for a fresh web
+assessment covering the latest four hours of macro, rates, currencies,
+equities, commodities, crypto, futures funding, open interest, liquidations,
+regulation, exchange incidents, and geopolitical risk. The result must be valid
+JSON with a `BULLISH`, `BEARISH`, or `NEUTRAL` label, bounded confidence,
+evidence-based explanation, and up to eight consulted source URLs.
+
+Validated results are stored in MongoDB with `chatgpt_web_search` provenance and
+cached in Redis for the trading signal filter. The old RSS, Reddit, and Twitter
+poller remains available only when `ORBIT_LEGACY_SENTIMENT_UPDATES=true`; it is
+disabled by default to avoid duplicate analysis and uncontrolled web-search
+fan-out.
 
 ## Operational boundary
 

--- a/src/orbit/core/sentimen_cron.py
+++ b/src/orbit/core/sentimen_cron.py
@@ -2,12 +2,11 @@
 sentimen_cron
 =============
 
-Provides :class:`Croner`, a simple scheduler that runs the
-:class:`SentimentWorkflow` on two cadences:
+Provides :class:`Croner`, a scheduler that runs live web-grounded sentiment
+hourly. The legacy source poller can be enabled explicitly:
 
-1. **Full analysis** — once per hour (top of the hour).
-2. **News + Reddit + Twitter update** — every ``NEWS_POLL_INTERVAL_SECONDS``
-   seconds (default 10 minutes).
+1. **ChatGPT web-search analysis** — once per hour.
+2. **Legacy News + Reddit + Twitter update** — disabled by default.
 
 Last-fetch timestamps are persisted in Redis so they survive process
 restarts.  All heavy dependencies (LLM, workflow, Redis) can be **injected**
@@ -17,6 +16,7 @@ through the constructor.
 import time
 import asyncio
 import logging
+import os
 from datetime import datetime, timezone, timedelta
 from typing import Any, Dict, Optional
 
@@ -44,7 +44,7 @@ DRIFT_WINDOW_SECONDS: int = 86_400  # 24 hours
 
 
 class Croner(ExceptionManager, RedisManager):
-    """Hourly full-analysis + 10-minute news+Reddit+Twitter update scheduler.
+    """Hourly web-search sentiment scheduler with optional legacy updates.
 
     Args:
         sentiment_workflow: Pre-built :class:`SentimentWorkflow`.  When
@@ -55,6 +55,7 @@ class Croner(ExceptionManager, RedisManager):
         news_poll_interval: Override the news-polling interval in seconds.
         sentiment_drift_threshold: Override the confidence threshold that
             triggers an immediate full analysis on sentiment drift.
+        legacy_updates_enabled: Enable the legacy 10-minute source poller.
     """
 
     def __init__(
@@ -64,6 +65,7 @@ class Croner(ExceptionManager, RedisManager):
         custom_logger: Optional[logging.Logger] = None,
         news_poll_interval: int = NEWS_POLL_INTERVAL_SECONDS,
         sentiment_drift_threshold: float = SENTIMENT_DRIFT_THRESHOLD,
+        legacy_updates_enabled: Optional[bool] = None,
     ) -> None:
         ExceptionManager.__init__(self, custom_logger)
         RedisManager.__init__(self, redis_client=redis_client)
@@ -76,6 +78,12 @@ class Croner(ExceptionManager, RedisManager):
 
         self.news_poll_interval: int = news_poll_interval
         self.sentiment_drift_threshold: float = sentiment_drift_threshold
+        self.legacy_updates_enabled = (
+            legacy_updates_enabled
+            if legacy_updates_enabled is not None
+            else os.getenv("ORBIT_LEGACY_SENTIMENT_UPDATES", "false").lower()
+            in {"1", "true", "yes"}
+        )
 
     # ------------------------------------------------------------------
     # DRIFT WINDOW MANAGEMENT
@@ -151,8 +159,11 @@ class Croner(ExceptionManager, RedisManager):
         Returns:
             The analysis result dict.
         """
-        result = await self.sentimental_workflow.run_analysis()
+        result = await self.sentimental_workflow.run_web_search_analysis()
         logger.info(f"Sentiment Analysis Result: {result}")
+        if not result.get("success"):
+            logger.error("Hourly web-search sentiment failed: %s", result.get("error"))
+            return result
         sentiment = result.get("sentiment")
         sentiment_confidence = result.get("confidence")
         sentiment_reasoning = result.get("explanation")
@@ -306,15 +317,16 @@ class Croner(ExceptionManager, RedisManager):
                 last_run = self.get_hourly_last_run()
 
                 if last_run != current_hour:
-                    asyncio.run(self.run_once())
-                    self.set_hourly_last_run(current_hour)
-                    time.sleep(self.news_poll_interval)
+                    result = asyncio.run(self.run_once())
+                    if result.get("success"):
+                        self.set_hourly_last_run(current_hour)
 
                 # Check whether the 24-hour drift window has elapsed and
                 # reset the counter (sending a Discord alert) if so.
                 self._check_and_reset_drift_window()
 
-                asyncio.run(self.run_news_update_once())
+                if self.legacy_updates_enabled:
+                    asyncio.run(self.run_news_update_once())
                 time.sleep(self.news_poll_interval)
             except Exception as e:
                 self.handle_exception(

--- a/src/orbit/market_intelligence/llm/llm_endpoint.py
+++ b/src/orbit/market_intelligence/llm/llm_endpoint.py
@@ -22,7 +22,7 @@ load_dotenv()
 # ---------------------------------------------------------------------------
 # Model configuration
 # ---------------------------------------------------------------------------
-OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5.6-terra")
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-5.6-luna")
 OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "openrouter/free")
 GROQ_MODELS = ["openai/gpt-oss-120b", "llama-3.1-8b-instant", "gemma2-9b-it"]
 

--- a/src/orbit/market_intelligence/llm/llm_endpoint.py
+++ b/src/orbit/market_intelligence/llm/llm_endpoint.py
@@ -2,7 +2,7 @@
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Any, Optional, Protocol, cast
 
 from langchain_groq import ChatGroq
 import redis
@@ -27,6 +27,14 @@ OPENROUTER_MODEL = os.getenv("OPENROUTER_MODEL", "openrouter/free")
 GROQ_MODELS = ["openai/gpt-oss-120b", "llama-3.1-8b-instant", "gemma2-9b-it"]
 
 logger = logging.getLogger("Orbit")
+
+
+class WebSearchProvider(Protocol):
+    """Structural type for providers that support grounded web queries."""
+
+    def invoke_web_search(self, prompt: str) -> Any:
+        """Return a web-grounded response for ``prompt``."""
+
 
 class LLM(ExceptionManager):
     """Use OpenAI first, with optional OpenRouter and Groq fallbacks."""
@@ -134,7 +142,8 @@ class LLM(ExceptionManager):
             raise RuntimeError(
                 "The configured OpenAI provider does not support live web search"
             )
-        response = web_invoke(prompt)
+        web_provider = cast(WebSearchProvider, provider)
+        response = web_provider.invoke_web_search(prompt)
         content = response.content if hasattr(response, "content") else response
         if not content or not str(content).strip():
             raise RuntimeError("OpenAI web search returned an empty response")

--- a/src/orbit/market_intelligence/llm/llm_endpoint.py
+++ b/src/orbit/market_intelligence/llm/llm_endpoint.py
@@ -124,6 +124,22 @@ class LLM(ExceptionManager):
 
         raise RuntimeError("All configured market-intelligence providers failed") from last_error
 
+    def invoke_web_search(self, prompt: str) -> str:
+        """Run a web-grounded query through the primary OpenAI provider only."""
+        prompt_token_length = len(prompt.split())
+        self._track_token_usage(prompt_token_length)
+        provider = self.openai_llm
+        web_invoke = getattr(provider, "invoke_web_search", None)
+        if not callable(web_invoke):
+            raise RuntimeError(
+                "The configured OpenAI provider does not support live web search"
+            )
+        response = web_invoke(prompt)
+        content = response.content if hasattr(response, "content") else response
+        if not content or not str(content).strip():
+            raise RuntimeError("OpenAI web search returned an empty response")
+        return str(content).strip()
+
     # -----------------------------------------------------------------------
     # Helpers
     # -----------------------------------------------------------------------

--- a/src/orbit/market_intelligence/llm/openai_client.py
+++ b/src/orbit/market_intelligence/llm/openai_client.py
@@ -13,7 +13,7 @@ from openai import OpenAI
 
 logger = logging.getLogger("Orbit")
 
-DEFAULT_OPENAI_MODEL = "gpt-5.6-terra"
+DEFAULT_OPENAI_MODEL = "gpt-5.6-luna"
 DEFAULT_MAX_OUTPUT_TOKENS = 2_000
 DEFAULT_INSTRUCTIONS = (
     "You are Orbit's market-intelligence analyst. Follow the requested output "

--- a/src/orbit/market_intelligence/llm/openai_client.py
+++ b/src/orbit/market_intelligence/llm/openai_client.py
@@ -6,6 +6,7 @@ import os
 from pathlib import Path
 import urllib.error
 import urllib.request
+import uuid
 from typing import Any, Callable, Optional
 
 from openai import OpenAI
@@ -68,6 +69,29 @@ class OpenAIResponsesClient:
         logger.info("OpenAI market-intelligence response generated with %s", self.model)
         return output_text.strip()
 
+    def invoke_web_search(self, prompt: str) -> str:
+        """Generate a response grounded by OpenAI's web-search tool."""
+        if not prompt or not prompt.strip():
+            raise ValueError("prompt must not be empty")
+
+        response = self.client.responses.create(
+            model=self.model,
+            instructions=DEFAULT_INSTRUCTIONS,
+            input=prompt,
+            tools=[{"type": "web_search"}],
+            max_output_tokens=self.max_output_tokens,
+        )
+        if response.status != "completed":
+            details = getattr(response, "incomplete_details", None)
+            raise RuntimeError(
+                f"OpenAI web-search response ended with status {response.status!r}: "
+                f"{details}"
+            )
+        output_text = response.output_text
+        if not output_text or not output_text.strip():
+            raise RuntimeError("OpenAI web search returned an empty response")
+        return output_text.strip()
+
 
 def default_auth_file() -> Path:
     """Return the Codex credential file location without requiring it to exist."""
@@ -94,6 +118,7 @@ class CodexOAuthResponsesClient:
         auth_file: Optional[os.PathLike[str] | str] = None,
         model: Optional[str] = None,
         timeout: float = 60.0,
+        web_search_timeout: Optional[float] = None,
         max_output_tokens: Optional[int] = None,
         endpoint: Optional[str] = None,
         urlopen: Callable[..., Any] = urllib.request.urlopen,
@@ -101,6 +126,11 @@ class CodexOAuthResponsesClient:
         self.auth_file = Path(auth_file).expanduser() if auth_file else default_auth_file()
         self.model = model or os.getenv("OPENAI_MODEL", DEFAULT_OPENAI_MODEL)
         self.timeout = timeout
+        self.web_search_timeout = web_search_timeout or float(
+            os.getenv("OPENAI_WEB_SEARCH_TIMEOUT", "300")
+        )
+        if self.web_search_timeout <= 0:
+            raise ValueError("OPENAI_WEB_SEARCH_TIMEOUT must be positive")
         self.max_output_tokens = max_output_tokens or int(
             os.getenv("OPENAI_MAX_OUTPUT_TOKENS", str(DEFAULT_MAX_OUTPUT_TOKENS))
         )
@@ -130,30 +160,53 @@ class CodexOAuthResponsesClient:
 
     def invoke(self, prompt: str) -> str:
         """Stream one sentiment-analysis response and return its complete text."""
+        return self._invoke(prompt, web_search=False)
+
+    def invoke_web_search(self, prompt: str) -> str:
+        """Stream one response with live external web search enabled."""
+        return self._invoke(prompt, web_search=True)
+
+    def _invoke(self, prompt: str, web_search: bool) -> str:
         if not prompt or not prompt.strip():
             raise ValueError("prompt must not be empty")
 
         access_token, account_id = self._credentials()
-        payload = json.dumps(
-            {
-                "model": self.model,
-                "instructions": DEFAULT_INSTRUCTIONS,
-                "input": [
-                    {
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": prompt}],
-                    }
-                ],
-                "stream": True,
-                "store": False,
-            }
-        ).encode("utf-8")
+        request_id = str(uuid.uuid4())
+        payload_data: dict[str, Any] = {
+            "model": self.model,
+            "instructions": DEFAULT_INSTRUCTIONS,
+            "input": [
+                {
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": prompt}],
+                }
+            ],
+            "stream": True,
+            "store": False,
+        }
+        if web_search:
+            payload_data.update(
+                {
+                    "tools": [{"type": "web_search", "external_web_access": True}],
+                    "tool_choice": "auto",
+                    "parallel_tool_calls": False,
+                    "reasoning": {"effort": "medium", "summary": "auto"},
+                    "include": [
+                        "reasoning.encrypted_content",
+                        "web_search_call.action.sources",
+                    ],
+                }
+            )
+        payload = json.dumps(payload_data).encode("utf-8")
         headers = {
             "Authorization": f"Bearer {access_token}",
             "Content-Type": "application/json",
             "Accept": "text/event-stream",
             "OpenAI-Beta": "responses=experimental",
             "originator": "orbit",
+            "session-id": request_id,
+            "thread-id": request_id,
+            "x-client-request-id": request_id,
         }
         if account_id:
             headers["ChatGPT-Account-Id"] = account_id
@@ -164,7 +217,8 @@ class CodexOAuthResponsesClient:
         assistant_text: list[str] = []
         completed = False
         try:
-            with self._urlopen(request, timeout=self.timeout) as response:
+            request_timeout = self.web_search_timeout if web_search else self.timeout
+            with self._urlopen(request, timeout=request_timeout) as response:
                 for raw_line in response:
                     line = raw_line.decode("utf-8", errors="replace").strip()
                     if not line.startswith("data: "):
@@ -180,7 +234,7 @@ class CodexOAuthResponsesClient:
                             assistant_text.append(delta)
                     elif event_type == "response.completed":
                         completed = True
-                    elif event_type == "error":
+                    elif event_type in {"error", "response.failed", "response.incomplete"}:
                         raise RuntimeError(f"OpenAI streaming error: {event}")
         except urllib.error.HTTPError as error:
             details = error.read().decode("utf-8", errors="replace")

--- a/src/orbit/market_intelligence/llm/prompt_manager.py
+++ b/src/orbit/market_intelligence/llm/prompt_manager.py
@@ -28,6 +28,27 @@ class PromptManager:
     # Local prompt templates (identical to the current hard‑coded prompts)
     # ------------------------------------------------------------------
     _LOCAL_TEMPLATES = {
+        "hourly_web_search_sentiment": (
+            "You are Orbit's institutional market-intelligence analyst. The current "
+            "UTC time is {current_time_utc}. Use live web search to assess information "
+            "published or materially updated during the last four hours.\n\n"
+            "Cover global financial markets and cryptocurrency futures, prioritizing:\n"
+            "- central banks, inflation, rates, bonds, USD, equities, gold, and oil\n"
+            "- Bitcoin, Ethereum, major crypto assets, ETFs, regulation, and institutional flows\n"
+            "- futures funding, open interest, liquidations, basis, leverage, and exchange incidents\n"
+            "- geopolitical or macro events with immediate risk-on/risk-off impact\n\n"
+            "Use credible, recent sources. Treat rumors and unsupported social posts as noise. "
+            "Do not infer a directional signal when evidence is stale, mixed, or immaterial. "
+            "This is a market sentiment input, not an instruction to place a trade.\n\n"
+            "Return ONLY valid JSON with this exact shape and no markdown:\n"
+            "{{\n"
+            '  "sentiment": "BULLISH" | "BEARISH" | "NEUTRAL",\n'
+            '  "confidence": <float from 0.0 to 1.0>,\n'
+            '  "explanation": "concise evidence-based synthesis",\n'
+            '  "sources": ["https://source.example/article"]\n'
+            "}}\n"
+            "Include 2-8 source URLs actually consulted."
+        ),
         "reddit_chunk_analysis": (
             "You are a financial sentiment analyst.\n\n"
             "Analyse the following Reddit posts (separated by ---) and determine the\n"

--- a/src/orbit/market_intelligence/sentimental_workflow.py
+++ b/src/orbit/market_intelligence/sentimental_workflow.py
@@ -27,8 +27,8 @@ Also provides a lightweight `run_news_update()` path that:
 
 import time
 import logging
-from pydantic import BaseModel, Field
-from datetime import datetime
+from pydantic import BaseModel, Field, field_validator
+from datetime import datetime, timezone
 from typing import Dict, Any, List, Optional
 from zoneinfo import ZoneInfo
 
@@ -105,6 +105,20 @@ class NewsSentiment(BaseModel):
     sentiment: SentimentType
     confidence: float = Field(ge=0.0, le=1.0)
     explanation: str
+
+
+class WebSearchSentiment(Sentiment):
+    """Validated hourly sentiment grounded in live web sources."""
+
+    sources: List[str] = Field(min_length=1, max_length=8)
+
+    @field_validator("sources")
+    @classmethod
+    def validate_sources(cls, sources: List[str]) -> List[str]:
+        unique_sources = list(dict.fromkeys(sources))
+        if any(not source.startswith(("https://", "http://")) for source in unique_sources):
+            raise ValueError("web-search sources must be HTTP URLs")
+        return unique_sources
 
 
 class SentimentWorkflow(ExceptionManager):
@@ -838,6 +852,52 @@ class SentimentWorkflow(ExceptionManager):
                 "success": False,
                 "error": str(e),
                 "timestamp": get_indian_time().isoformat(),
+            }
+
+    async def run_web_search_analysis(self) -> Dict[str, Any]:
+        """Run the hourly live-web market assessment and persist its result."""
+        start_time = time.time()
+        try:
+            current_time = datetime.now(timezone.utc).isoformat()
+            prompt = self.prompt_manager.get_prompt(
+                "hourly_web_search_sentiment", current_time_utc=current_time
+            )
+            raw_content = self.llm.invoke_web_search(prompt)
+            data = extract_json(str(raw_content))
+            result = WebSearchSentiment(**data)
+            processing_time = int((time.time() - start_time) * 1000)
+            record = SentimentRecord(
+                combined_sentiment={
+                    "sentiment": result.sentiment,
+                    "confidence": result.confidence,
+                    "explanation": result.explanation,
+                },
+                reddit_sentiment={"source": "disabled_for_hourly_web_search"},
+                news_sentiment={
+                    "source": "chatgpt_web_search",
+                    "sources": result.sources,
+                    "summary": result.explanation,
+                },
+                market_indicators={},
+                twitter_sentiment={"source": "disabled_for_hourly_web_search"},
+                processing_time_ms=processing_time,
+            )
+            record_id = self.mongodb.save_sentiment(record)
+            return {
+                "success": True,
+                "timestamp": get_indian_time().isoformat(),
+                "database_id": record_id,
+                "source": "chatgpt_web_search",
+                **result.model_dump(),
+                "processing_time_ms": processing_time,
+            }
+        except Exception as error:
+            self.handle_exception(error, context_description="run_web_search_analysis")
+            return {
+                "success": False,
+                "error": str(error),
+                "timestamp": get_indian_time().isoformat(),
+                "source": "chatgpt_web_search",
             }
 
     # ------------------------------------------------------------------

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -20,7 +20,8 @@ class TestCore(unittest.TestCase):
     @patch("orbit.core.sentimen_cron.SentimentWorkflow")
     def test_sentiment(self, MockWorkflow):
         mock_workflow_instance = MagicMock()
-        mock_workflow_instance.run_analysis = AsyncMock(return_value={
+        mock_workflow_instance.run_web_search_analysis = AsyncMock(return_value={
+            "success": True,
             "sentiment": "BULLISH",
             "confidence": 0.9,
             "reasoning": "Strong buying pressure"
@@ -39,6 +40,20 @@ class TestCore(unittest.TestCase):
         mock_redis.set.assert_any_call("market_sentiments", "BULLISH")
 
         assert result["sentiment"] == "BULLISH"
+
+    @timeout(30)
+    def test_failed_hourly_web_search_preserves_cached_sentiment(self):
+        workflow = MagicMock()
+        workflow.run_web_search_analysis = AsyncMock(
+            return_value={"success": False, "error": "web search unavailable"}
+        )
+        mock_redis = MagicMock()
+        croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
+
+        result = asyncio.run(croner.run_once())
+
+        self.assertFalse(result["success"])
+        mock_redis.set.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_market_intelligence.py
+++ b/tests/test_market_intelligence.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import os
 from unittest.mock import MagicMock, patch
 os.environ["GROQ_API_KEY"] = "test_key"
@@ -96,3 +97,57 @@ def test_run_analysis_success():
     assert result["sentiment"] == "BEARISH"
 
     workflow._save_to_database.assert_called_once()
+
+
+def test_hourly_web_search_analysis_is_validated_and_persisted():
+    mock_llm = MagicMock()
+    mock_llm.invoke_web_search.return_value = json.dumps(
+        {
+            "sentiment": "BULLISH",
+            "confidence": 0.82,
+            "explanation": "Rates eased while crypto flows strengthened.",
+            "sources": ["https://example.com/market-update"],
+        }
+    )
+    with (
+        patch("orbit.market_intelligence.sentimental_workflow.RedditClient"),
+        patch("orbit.market_intelligence.sentimental_workflow.TwitterClient"),
+        patch("orbit.market_intelligence.sentimental_workflow.MongoDBManager"),
+    ):
+        workflow = SentimentWorkflow(llm=mock_llm)
+    workflow.mongodb.save_sentiment.return_value = "record-id"
+
+    result = asyncio.run(workflow.run_web_search_analysis())
+
+    assert result["success"] is True
+    assert result["sentiment"] == "BULLISH"
+    assert result["source"] == "chatgpt_web_search"
+    record = workflow.mongodb.save_sentiment.call_args.args[0]
+    assert record.news_sentiment["source"] == "chatgpt_web_search"
+    assert record.news_sentiment["sources"] == [
+        "https://example.com/market-update"
+    ]
+
+
+def test_hourly_web_search_analysis_rejects_missing_sources():
+    mock_llm = MagicMock()
+    mock_llm.invoke_web_search.return_value = json.dumps(
+        {
+            "sentiment": "NEUTRAL",
+            "confidence": 0.2,
+            "explanation": "No sourced evidence.",
+            "sources": [],
+        }
+    )
+    with (
+        patch("orbit.market_intelligence.sentimental_workflow.RedditClient"),
+        patch("orbit.market_intelligence.sentimental_workflow.TwitterClient"),
+        patch("orbit.market_intelligence.sentimental_workflow.MongoDBManager"),
+    ):
+        workflow = SentimentWorkflow(llm=mock_llm)
+    workflow.handle_exception = MagicMock()
+
+    result = asyncio.run(workflow.run_web_search_analysis())
+
+    assert result["success"] is False
+    workflow.mongodb.save_sentiment.assert_not_called()

--- a/tests/test_market_intelligence.py
+++ b/tests/test_market_intelligence.py
@@ -115,14 +115,15 @@ def test_hourly_web_search_analysis_is_validated_and_persisted():
         patch("orbit.market_intelligence.sentimental_workflow.MongoDBManager"),
     ):
         workflow = SentimentWorkflow(llm=mock_llm)
-    workflow.mongodb.save_sentiment.return_value = "record-id"
+    save_sentiment = MagicMock(return_value="record-id")
+    workflow.mongodb.save_sentiment = save_sentiment
 
     result = asyncio.run(workflow.run_web_search_analysis())
 
     assert result["success"] is True
     assert result["sentiment"] == "BULLISH"
     assert result["source"] == "chatgpt_web_search"
-    record = workflow.mongodb.save_sentiment.call_args.args[0]
+    record = save_sentiment.call_args.args[0]
     assert record.news_sentiment["source"] == "chatgpt_web_search"
     assert record.news_sentiment["sources"] == [
         "https://example.com/market-update"
@@ -146,8 +147,10 @@ def test_hourly_web_search_analysis_rejects_missing_sources():
     ):
         workflow = SentimentWorkflow(llm=mock_llm)
     workflow.handle_exception = MagicMock()
+    save_sentiment = MagicMock()
+    workflow.mongodb.save_sentiment = save_sentiment
 
     result = asyncio.run(workflow.run_web_search_analysis())
 
     assert result["success"] is False
-    workflow.mongodb.save_sentiment.assert_not_called()
+    save_sentiment.assert_not_called()

--- a/tests/test_market_intelligence_llm.py
+++ b/tests/test_market_intelligence_llm.py
@@ -66,6 +66,23 @@ def test_openai_client_rejects_nonempty_incomplete_output() -> None:
         client.invoke("Classify this market")
 
 
+def test_openai_client_uses_web_search_tool() -> None:
+    sdk_client = MagicMock()
+    sdk_client.responses.create.return_value = SimpleNamespace(
+        status="completed", incomplete_details=None, output_text="web result"
+    )
+    client = OpenAIResponsesClient(client=sdk_client)
+
+    assert client.invoke_web_search("Assess markets") == "web result"
+    sdk_client.responses.create.assert_called_once_with(
+        model=DEFAULT_OPENAI_MODEL,
+        instructions=DEFAULT_INSTRUCTIONS,
+        input="Assess markets",
+        tools=[{"type": "web_search"}],
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
+    )
+
+
 def test_codex_oauth_client_streams_responses(tmp_path) -> None:
     auth_file = tmp_path / "auth.json"
     auth_file.write_text(
@@ -126,6 +143,49 @@ def test_codex_oauth_client_requires_access_token(tmp_path) -> None:
         client.invoke("Classify this market")
 
 
+def test_codex_oauth_client_enables_external_web_search(tmp_path) -> None:
+    auth_file = tmp_path / "auth.json"
+    auth_file.write_text(
+        json.dumps({"tokens": {"access_token": "secret", "account_id": "acct"}}),
+        encoding="utf-8",
+    )
+
+    class StreamingResponse:
+        def __enter__(self):
+            return iter(
+                [
+                    b'data: {"type":"response.output_text.delta","delta":"result"}\n',
+                    b'data: {"type":"response.completed"}\n',
+                    b"data: [DONE]\n",
+                ]
+            )
+
+        def __exit__(self, *_args):
+            return False
+
+    requests = []
+
+    def urlopen(request, timeout):
+        requests.append((request, timeout))
+        return StreamingResponse()
+
+    client = CodexOAuthResponsesClient(auth_file=auth_file, urlopen=urlopen)
+
+    assert client.invoke_web_search("Assess markets") == "result"
+    request, timeout = requests[0]
+    payload = json.loads(request.data)
+    assert timeout == 300.0
+    assert payload["tools"] == [
+        {"type": "web_search", "external_web_access": True}
+    ]
+    assert payload["include"] == [
+        "reasoning.encrypted_content",
+        "web_search_call.action.sources",
+    ]
+    assert request.get_header("Session-id")
+    assert request.get_header("Thread-id")
+
+
 def test_llm_prefers_openai_without_startup_request() -> None:
     openai_client = MagicMock()
     openai_client.invoke.return_value = "primary"
@@ -140,6 +200,22 @@ def test_llm_prefers_openai_without_startup_request() -> None:
 
     openai_client.invoke.assert_not_called()
     assert llm.invoke("market prompt") == "primary"
+    fallback.invoke.assert_not_called()
+
+
+def test_llm_web_search_uses_only_openai_provider() -> None:
+    openai_client = MagicMock()
+    openai_client.invoke_web_search.return_value = "grounded result"
+    fallback = MagicMock()
+    llm = LLM(
+        openai_client=openai_client,
+        openrouter_client=fallback,
+        groq_client=fallback,
+        redis_client=_redis_mock(),
+    )
+
+    assert llm.invoke_web_search("market prompt") == "grounded result"
+    openai_client.invoke_web_search.assert_called_once_with("market prompt")
     fallback.invoke.assert_not_called()
 
 


### PR DESCRIPTION
## Summary

- replace the default legacy sentiment polling cycle with one hourly ChatGPT OAuth web-search analysis
- cover financial markets, crypto, and futures with validated source URLs and persisted provider provenance
- update Redis sentiment only after a successful grounded response, while retaining legacy RSS/social polling behind `ORBIT_LEGACY_SENTIMENT_UPDATES=true`
- add configuration, architecture documentation, and coverage for the new invocation and workflow paths

## Validation

- live OAuth web-search request completed successfully with a sourced sentiment response
- `python3 -m compileall src tests`
- `git diff --check`
- targeted pytest suite was not run locally because pytest is unavailable in the managed system Python; CI will run the repository test suite