### PR TITLE
Enable user namespaces for Codex sandbox

### DIFF
--- a/.github/workflows/codex-automation.yml
+++ b/.github/workflows/codex-automation.yml
@@ -88,10 +88,14 @@ jobs:
             `;
             fs.writeFileSync(process.env.TASK_FILE, prompt);
 
-      - name: Install Codex sandbox dependency
+      - name: Install Codex sandbox prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bubblewrap
+          sudo apt-get install --yes bubblewrap apparmor-profiles apparmor-utils
+          sudo install -m 0644 \
+            /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+            /etc/apparmor.d/bwrap-userns-restrict
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 
       - name: Install pinned Codex CLI
         run: npm install --global @openai/codex@0.147.0
@@ -259,10 +263,14 @@ jobs:
             `;
             fs.writeFileSync(process.env.TASK_FILE, prompt);
 
-      - name: Install Codex sandbox dependency
+      - name: Install Codex sandbox prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bubblewrap
+          sudo apt-get install --yes bubblewrap apparmor-profiles apparmor-utils
+          sudo install -m 0644 \
+            /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+            /etc/apparmor.d/bwrap-userns-restrict
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 
       - name: Install pinned Codex CLI
         run: npm install --global @openai/codex@0.147.0

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -36,10 +36,14 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Install Codex sandbox dependency
+      - name: Install Codex sandbox prerequisites
         run: |
           sudo apt-get update
-          sudo apt-get install --yes bubblewrap
+          sudo apt-get install --yes bubblewrap apparmor-profiles apparmor-utils
+          sudo install -m 0644 \
+            /usr/share/apparmor/extra-profiles/bwrap-userns-restrict \
+            /etc/apparmor.d/bwrap-userns-restrict
+          sudo apparmor_parser -r /etc/apparmor.d/bwrap-userns-restrict
 
       - name: Install pinned Codex CLI
         run: npm install --global @openai/codex@0.147.0

--- a/docs/operations/CODEX_AUTOMATION.md
+++ b/docs/operations/CODEX_AUTOMATION.md
@@ -12,10 +12,11 @@ unencoded contents of Codex CLI `auth.json`. Configure a GitHub environment name
 
 The workflow writes the credential to `$RUNNER_TEMP/codex-home/auth.json` with a
 restrictive umask, validates it as JSON, and removes it in an `always()` cleanup
-step. Each job installs the host `bubblewrap` package before installing Codex so
-the CLI can initialize its Linux sandbox without falling back to the bundled
-binary. Codex CLI is pinned to `0.147.0` and runs ephemerally in a
-`workspace-write` sandbox.
+step. Each job installs the host `bubblewrap` package and loads Ubuntu 24.04's
+extra `bwrap-userns-restrict` AppArmor profile before installing Codex. This lets
+the CLI create the user namespace required by its Linux sandbox without
+disabling the AppArmor restriction globally. Codex CLI is pinned to `0.147.0`
+and runs ephemerally in a `workspace-write` sandbox.
 
 ## Autonomous issue implementation
 

--- a/docs/operations/CODEX_PR_REVIEW.md
+++ b/docs/operations/CODEX_PR_REVIEW.md
@@ -20,6 +20,8 @@ commits, caches, or pull-request content.
 - Draft PRs are not reviewed until marked ready.
 - A new commit cancels the obsolete review and starts a new one.
 - Codex CLI is pinned to `0.147.0` for reproducibility.
+- The job installs `bubblewrap` and loads Ubuntu 24.04's extra AppArmor profile
+  so Codex can create the user namespace required by its Linux sandbox.
 - Repository/user Codex configuration is ignored; authentication still comes
   from the temporary `CODEX_HOME`.
 - Codex cannot modify the checkout because the sandbox is read-only.


### PR DESCRIPTION
## Summary

- install the host `bubblewrap`, `apparmor-profiles`, and `apparmor-utils` packages in every Ubuntu 24.04 Codex job
- copy and load the `bwrap-userns-restrict` AppArmor profile before running Codex
- document the Linux sandbox prerequisites for automation and PR review

## Why

The issue implementation and requested-change repair jobs initially invoked Codex without installing its Linux sandbox dependency. Installing `bubblewrap` removed that warning, but Ubuntu 24.04 continued to restrict the unprivileged user namespace required by the sandbox, producing `bwrap: loopback: Failed RTM_NEWADDR: Operation not permitted` before commands could start.

The workflows now follow OpenAI's Ubuntu 24.04 prerequisite: load the distribution's extra AppArmor profile for bubblewrap. This retains the existing read/write sandbox boundaries without disabling the AppArmor restriction globally.

## Impact

Codex can inspect, edit, test, and review changes on GitHub-hosted Ubuntu 24.04 runners instead of terminating during sandbox startup.

## Validation

- `git diff --check`
- parsed both modified workflow files with PyYAML
