### PR TITLE
Update PR code review workflow

### DIFF
--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   review:
-    uses: ipankaj18/code-kit/.github/workflows/pr-code-review.yml@6e0369a34466e2b33ccd130eb81d8bb0233574d8
+    uses: ipankaj18/code-kit/.github/workflows/pr-code-review.yml@main
     with:
       review_prompt: >-
         Review this pull request as a strict production-safety gate for a

--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   review:
-    uses: ipankaj18/code-kit/.github/workflows/pr-code-review.yml@056867a00859225c4c1c36ed05b4b7637bbf07fe
+    uses: ipankaj18/code-kit/.github/workflows/pr-code-review.yml@6e0369a34466e2b33ccd130eb81d8bb0233574d8
     with:
       review_prompt: >-
         Review this pull request as a strict production-safety gate for a


### PR DESCRIPTION
## Summary

- update the reusable `pr-code-review` workflow reference to track `code-kit/main`
- automatically use the latest shared PR review implementation on each run

## Why

Orbit was pinned to an older `code-kit` revision and therefore did not automatically receive updates to the shared PR review workflow.

## Impact

New pull-request review runs will use the current workflow from `code-kit/main`. The Orbit-specific review prompt and permissions remain unchanged.

## Validation

- `git diff --check`
- confirmed the workflow reference is `ipankaj18/code-kit/.github/workflows/pr-code-review.yml@main`
