### PR TITLE
Pass Antigravity credentials to PR review

### DIFF
--- a/.github/workflows/pr-code-review.yml
+++ b/.github/workflows/pr-code-review.yml
@@ -23,3 +23,4 @@ jobs:
         speculative concerns, and pre-existing issues outside the diff.
     secrets:
       CODEX_AUTH_JSON: ${{ secrets.CODEX_AUTH_JSON }}
+      ANTIGRAVITY_OAUTH_TOKEN: ${{ secrets.ANTIGRAVITY_OAUTH_TOKEN }}


### PR DESCRIPTION
## What changed

Pass the repository's `ANTIGRAVITY_OAUTH_TOKEN` Actions secret into the reusable PR review workflow.

## Root cause

The credential is configured in Orbit, but reusable workflows do not receive caller secrets automatically. The caller mapped `CODEX_AUTH_JSON` only, so the Antigravity authentication step received an empty environment value.

## Impact

The Antigravity review job can install its configured OAuth token instead of failing before review execution.

## Validation

- `git diff --check`
- Parsed the workflow with PyYAML and asserted the Antigravity secret mapping.
