### PR TITLE
Stabilize and sharpen market sentiment signals

### DIFF
--- a/.github/workflows/static-checker.yml
+++ b/.github/workflows/static-checker.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Configure Poetry
         run: |
           poetry config virtualenvs.in-project true
+          # The spot and futures Binance connectors share the `binance` package.
+          # Parallel installation can interleave writes and corrupt modules.
+          poetry config installer.parallel false
 
       - name: Install dependencies
         run: |

--- a/src/orbit/core/redis_manager.py
+++ b/src/orbit/core/redis_manager.py
@@ -20,6 +20,8 @@ Key schema
 ``order:{order_id}``                – trade_id string
 ``{symbol}``                        – cooldown ISO-8601 timestamp
 ``market_sentiments``               – current sentiment label
+``sentiment:pending_label``         – candidate regime awaiting confirmation
+``sentiment:pending_count``         – consecutive observations of that candidate
 ``ms_hourly_last_run``              – hour integer of last full analysis
 ``sentiment:last_news_fetch``       – ISO-8601 last news fetch time
 ``sentiment:last_reddit_fetch``     – ISO-8601 last Reddit fetch time
@@ -46,6 +48,8 @@ TRADE_KEY_PREFIX: str = "trade:"
 ORDER_KEY_PREFIX: str = "order:"
 
 REDIS_KEY_MARKET_SENTIMENT: str = "market_sentiments"
+REDIS_KEY_PENDING_SENTIMENT: str = "sentiment:pending_label"
+REDIS_KEY_PENDING_SENTIMENT_COUNT: str = "sentiment:pending_count"
 REDIS_KEY_HOURLY_LAST_RUN: str = "ms_hourly_last_run"
 REDIS_KEY_LAST_NEWS_FETCH: str = "sentiment:last_news_fetch"
 REDIS_KEY_LAST_REDDIT_FETCH: str = "sentiment:last_reddit_fetch"
@@ -243,6 +247,27 @@ class RedisManager:
     def set_market_sentiment(self, sentiment: str) -> None:
         """Cache the current market-sentiment label."""
         self.redis_set(REDIS_KEY_MARKET_SENTIMENT, sentiment)
+
+    def record_pending_sentiment(self, sentiment: str) -> int:
+        """Record a consecutive candidate regime and return its observation count."""
+        current = self.redis_get(REDIS_KEY_PENDING_SENTIMENT)
+        if current != sentiment:
+            self.redis_set(REDIS_KEY_PENDING_SENTIMENT, sentiment)
+            self.redis_set(REDIS_KEY_PENDING_SENTIMENT_COUNT, "1")
+            return 1
+
+        raw_count = self.redis_get(REDIS_KEY_PENDING_SENTIMENT_COUNT)
+        try:
+            count = int(raw_count or 0) + 1
+        except (TypeError, ValueError):
+            count = 1
+        self.redis_set(REDIS_KEY_PENDING_SENTIMENT_COUNT, str(count))
+        return count
+
+    def clear_pending_sentiment(self) -> None:
+        """Clear a candidate regime after it is accepted or invalidated."""
+        self.redis_delete(REDIS_KEY_PENDING_SENTIMENT)
+        self.redis_delete(REDIS_KEY_PENDING_SENTIMENT_COUNT)
 
     # ------------------------------------------------------------------
     # Hourly-run tracking  (ms_hourly_last_run → hour integer)

--- a/src/orbit/core/redis_manager.py
+++ b/src/orbit/core/redis_manager.py
@@ -255,21 +255,29 @@ class RedisManager:
         self.redis_set(REDIS_KEY_MARKET_SENTIMENT, sentiment)
 
     def record_pending_sentiment(
-        self, sentiment: str, base_sentiment: str
-    ) -> Optional[int]:
-        """Atomically record a candidate if the active regime still matches.
+        self,
+        sentiment: str,
+        base_sentiment: str,
+        confirmations_required: int,
+    ) -> Optional[tuple[int, bool]]:
+        """Atomically record and, at threshold, commit a candidate regime.
 
         ``None`` means another scheduler changed the market regime after it was
-        read by the caller, so this observation must not confirm stale evidence.
+        read by the caller. Otherwise returns ``(count, was_committed)``.
         """
         script = """
         if redis.call('GET', KEYS[1]) ~= ARGV[1] then
-            return -1
+            return 0
         end
         local count = 1
         if redis.call('GET', KEYS[2]) == ARGV[2]
             and redis.call('GET', KEYS[3]) == ARGV[1] then
             count = tonumber(redis.call('GET', KEYS[4]) or '0') + 1
+        end
+        if count >= tonumber(ARGV[4]) then
+            redis.call('SET', KEYS[1], ARGV[2])
+            redis.call('DEL', KEYS[2], KEYS[3], KEYS[4])
+            return -count
         end
         redis.call('SET', KEYS[2], ARGV[2], 'EX', ARGV[3])
         redis.call('SET', KEYS[3], ARGV[1], 'EX', ARGV[3])
@@ -287,11 +295,42 @@ class RedisManager:
                 base_sentiment,
                 sentiment,
                 str(_PENDING_SENTIMENT_TTL),
+                str(confirmations_required),
             ))
-            return None if count < 0 else count
+            if count == 0:
+                return None
+            return abs(count), count < 0
         except Exception as e:
             logger.exception("[Redis] Atomic pending-sentiment update failed: %s", e)
             return None
+
+    def set_market_sentiment_if_current(
+        self, expected: Optional[str], sentiment: str
+    ) -> bool:
+        """Atomically change regime only if its cached value is still expected."""
+        script = """
+        local current = redis.call('GET', KEYS[1]) or ''
+        if current ~= ARGV[1] then
+            return 0
+        end
+        redis.call('SET', KEYS[1], ARGV[2])
+        redis.call('DEL', KEYS[2], KEYS[3], KEYS[4])
+        return 1
+        """
+        try:
+            return bool(self.redis_client.eval(
+                script,
+                4,
+                REDIS_KEY_MARKET_SENTIMENT,
+                REDIS_KEY_PENDING_SENTIMENT,
+                REDIS_KEY_PENDING_SENTIMENT_BASE,
+                REDIS_KEY_PENDING_SENTIMENT_COUNT,
+                expected or "",
+                sentiment,
+            ))
+        except Exception as e:
+            logger.exception("[Redis] Conditional market-sentiment update failed: %s", e)
+            return False
 
     def set_market_sentiment_and_clear_pending(self, sentiment: str) -> None:
         """Atomically establish a market regime and discard older evidence."""

--- a/src/orbit/core/redis_manager.py
+++ b/src/orbit/core/redis_manager.py
@@ -254,51 +254,75 @@ class RedisManager:
         """Cache the current market-sentiment label."""
         self.redis_set(REDIS_KEY_MARKET_SENTIMENT, sentiment)
 
-    def record_pending_sentiment(self, sentiment: str, base_sentiment: str) -> int:
-        """Record an expiring candidate regime and return its observation count."""
-        current = self.redis_get(REDIS_KEY_PENDING_SENTIMENT)
-        current_base = self.redis_get(REDIS_KEY_PENDING_SENTIMENT_BASE)
-        if current != sentiment or current_base != base_sentiment:
-            self.redis_setex(
-                REDIS_KEY_PENDING_SENTIMENT, _PENDING_SENTIMENT_TTL, sentiment
-            )
-            self.redis_setex(
-                REDIS_KEY_PENDING_SENTIMENT_BASE,
-                _PENDING_SENTIMENT_TTL,
-                base_sentiment,
-            )
-            self.redis_setex(
-                REDIS_KEY_PENDING_SENTIMENT_COUNT, _PENDING_SENTIMENT_TTL, "1"
-            )
-            return 1
+    def record_pending_sentiment(
+        self, sentiment: str, base_sentiment: str
+    ) -> Optional[int]:
+        """Atomically record a candidate if the active regime still matches.
 
-        raw_count = self.redis_get(REDIS_KEY_PENDING_SENTIMENT_COUNT)
-        try:
-            count = int(raw_count or 0) + 1
-        except (TypeError, ValueError):
-            count = 1
-        # Refresh both expiries together so a complete candidate observation
-        # always has a bounded lifetime from its most recent evidence.
-        self.redis_setex(
-            REDIS_KEY_PENDING_SENTIMENT, _PENDING_SENTIMENT_TTL, sentiment
-        )
-        self.redis_setex(
-            REDIS_KEY_PENDING_SENTIMENT_BASE,
-            _PENDING_SENTIMENT_TTL,
-            base_sentiment,
-        )
-        self.redis_setex(
-            REDIS_KEY_PENDING_SENTIMENT_COUNT,
-            _PENDING_SENTIMENT_TTL,
-            str(count),
-        )
+        ``None`` means another scheduler changed the market regime after it was
+        read by the caller, so this observation must not confirm stale evidence.
+        """
+        script = """
+        if redis.call('GET', KEYS[1]) ~= ARGV[1] then
+            return -1
+        end
+        local count = 1
+        if redis.call('GET', KEYS[2]) == ARGV[2]
+            and redis.call('GET', KEYS[3]) == ARGV[1] then
+            count = tonumber(redis.call('GET', KEYS[4]) or '0') + 1
+        end
+        redis.call('SET', KEYS[2], ARGV[2], 'EX', ARGV[3])
+        redis.call('SET', KEYS[3], ARGV[1], 'EX', ARGV[3])
+        redis.call('SET', KEYS[4], count, 'EX', ARGV[3])
         return count
+        """
+        try:
+            count = int(self.redis_client.eval(
+                script,
+                4,
+                REDIS_KEY_MARKET_SENTIMENT,
+                REDIS_KEY_PENDING_SENTIMENT,
+                REDIS_KEY_PENDING_SENTIMENT_BASE,
+                REDIS_KEY_PENDING_SENTIMENT_COUNT,
+                base_sentiment,
+                sentiment,
+                str(_PENDING_SENTIMENT_TTL),
+            ))
+            return None if count < 0 else count
+        except Exception as e:
+            logger.exception("[Redis] Atomic pending-sentiment update failed: %s", e)
+            return None
+
+    def set_market_sentiment_and_clear_pending(self, sentiment: str) -> None:
+        """Atomically establish a market regime and discard older evidence."""
+        script = """
+        redis.call('SET', KEYS[1], ARGV[1])
+        redis.call('DEL', KEYS[2], KEYS[3], KEYS[4])
+        return 1
+        """
+        try:
+            self.redis_client.eval(
+                script,
+                4,
+                REDIS_KEY_MARKET_SENTIMENT,
+                REDIS_KEY_PENDING_SENTIMENT,
+                REDIS_KEY_PENDING_SENTIMENT_BASE,
+                REDIS_KEY_PENDING_SENTIMENT_COUNT,
+                sentiment,
+            )
+        except Exception as e:
+            logger.exception("[Redis] Atomic market-sentiment update failed: %s", e)
 
     def clear_pending_sentiment(self) -> None:
         """Clear a candidate regime after it is accepted or invalidated."""
-        self.redis_delete(REDIS_KEY_PENDING_SENTIMENT)
-        self.redis_delete(REDIS_KEY_PENDING_SENTIMENT_BASE)
-        self.redis_delete(REDIS_KEY_PENDING_SENTIMENT_COUNT)
+        try:
+            self.redis_client.delete(
+                REDIS_KEY_PENDING_SENTIMENT,
+                REDIS_KEY_PENDING_SENTIMENT_BASE,
+                REDIS_KEY_PENDING_SENTIMENT_COUNT,
+            )
+        except Exception as e:
+            logger.exception("[Redis] Clearing pending sentiment failed: %s", e)
 
     # ------------------------------------------------------------------
     # Hourly-run tracking  (ms_hourly_last_run → hour integer)

--- a/src/orbit/core/redis_manager.py
+++ b/src/orbit/core/redis_manager.py
@@ -21,6 +21,7 @@ Key schema
 ``{symbol}``                        – cooldown ISO-8601 timestamp
 ``market_sentiments``               – current sentiment label
 ``sentiment:pending_label``         – expiring candidate regime awaiting confirmation
+``sentiment:pending_base``          – directional regime the candidate is measured against
 ``sentiment:pending_count``         – expiring consecutive-observation count
 ``ms_hourly_last_run``              – hour integer of last full analysis
 ``sentiment:last_news_fetch``       – ISO-8601 last news fetch time
@@ -49,6 +50,7 @@ ORDER_KEY_PREFIX: str = "order:"
 
 REDIS_KEY_MARKET_SENTIMENT: str = "market_sentiments"
 REDIS_KEY_PENDING_SENTIMENT: str = "sentiment:pending_label"
+REDIS_KEY_PENDING_SENTIMENT_BASE: str = "sentiment:pending_base"
 REDIS_KEY_PENDING_SENTIMENT_COUNT: str = "sentiment:pending_count"
 REDIS_KEY_HOURLY_LAST_RUN: str = "ms_hourly_last_run"
 REDIS_KEY_LAST_NEWS_FETCH: str = "sentiment:last_news_fetch"
@@ -252,12 +254,18 @@ class RedisManager:
         """Cache the current market-sentiment label."""
         self.redis_set(REDIS_KEY_MARKET_SENTIMENT, sentiment)
 
-    def record_pending_sentiment(self, sentiment: str) -> int:
+    def record_pending_sentiment(self, sentiment: str, base_sentiment: str) -> int:
         """Record an expiring candidate regime and return its observation count."""
         current = self.redis_get(REDIS_KEY_PENDING_SENTIMENT)
-        if current != sentiment:
+        current_base = self.redis_get(REDIS_KEY_PENDING_SENTIMENT_BASE)
+        if current != sentiment or current_base != base_sentiment:
             self.redis_setex(
                 REDIS_KEY_PENDING_SENTIMENT, _PENDING_SENTIMENT_TTL, sentiment
+            )
+            self.redis_setex(
+                REDIS_KEY_PENDING_SENTIMENT_BASE,
+                _PENDING_SENTIMENT_TTL,
+                base_sentiment,
             )
             self.redis_setex(
                 REDIS_KEY_PENDING_SENTIMENT_COUNT, _PENDING_SENTIMENT_TTL, "1"
@@ -275,6 +283,11 @@ class RedisManager:
             REDIS_KEY_PENDING_SENTIMENT, _PENDING_SENTIMENT_TTL, sentiment
         )
         self.redis_setex(
+            REDIS_KEY_PENDING_SENTIMENT_BASE,
+            _PENDING_SENTIMENT_TTL,
+            base_sentiment,
+        )
+        self.redis_setex(
             REDIS_KEY_PENDING_SENTIMENT_COUNT,
             _PENDING_SENTIMENT_TTL,
             str(count),
@@ -284,6 +297,7 @@ class RedisManager:
     def clear_pending_sentiment(self) -> None:
         """Clear a candidate regime after it is accepted or invalidated."""
         self.redis_delete(REDIS_KEY_PENDING_SENTIMENT)
+        self.redis_delete(REDIS_KEY_PENDING_SENTIMENT_BASE)
         self.redis_delete(REDIS_KEY_PENDING_SENTIMENT_COUNT)
 
     # ------------------------------------------------------------------

--- a/src/orbit/core/redis_manager.py
+++ b/src/orbit/core/redis_manager.py
@@ -20,8 +20,8 @@ Key schema
 ``order:{order_id}``                – trade_id string
 ``{symbol}``                        – cooldown ISO-8601 timestamp
 ``market_sentiments``               – current sentiment label
-``sentiment:pending_label``         – candidate regime awaiting confirmation
-``sentiment:pending_count``         – consecutive observations of that candidate
+``sentiment:pending_label``         – expiring candidate regime awaiting confirmation
+``sentiment:pending_count``         – expiring consecutive-observation count
 ``ms_hourly_last_run``              – hour integer of last full analysis
 ``sentiment:last_news_fetch``       – ISO-8601 last news fetch time
 ``sentiment:last_reddit_fetch``     – ISO-8601 last Reddit fetch time
@@ -63,6 +63,10 @@ _TIMESTAMP_TTL: int = 172_800
 # TTL for drift keys (25 hours — slightly beyond the 24-hour window so Redis
 # never evicts them before the cron has a chance to read and reset them)
 _DRIFT_TTL: int = 90_000
+
+# Pending observations must belong to the same hourly confirmation window.
+# Allow one hour of scheduler delay, but never carry evidence across an outage.
+_PENDING_SENTIMENT_TTL: int = 7_200
 
 
 def _trade_key(trade_id: str) -> str:
@@ -249,11 +253,15 @@ class RedisManager:
         self.redis_set(REDIS_KEY_MARKET_SENTIMENT, sentiment)
 
     def record_pending_sentiment(self, sentiment: str) -> int:
-        """Record a consecutive candidate regime and return its observation count."""
+        """Record an expiring candidate regime and return its observation count."""
         current = self.redis_get(REDIS_KEY_PENDING_SENTIMENT)
         if current != sentiment:
-            self.redis_set(REDIS_KEY_PENDING_SENTIMENT, sentiment)
-            self.redis_set(REDIS_KEY_PENDING_SENTIMENT_COUNT, "1")
+            self.redis_setex(
+                REDIS_KEY_PENDING_SENTIMENT, _PENDING_SENTIMENT_TTL, sentiment
+            )
+            self.redis_setex(
+                REDIS_KEY_PENDING_SENTIMENT_COUNT, _PENDING_SENTIMENT_TTL, "1"
+            )
             return 1
 
         raw_count = self.redis_get(REDIS_KEY_PENDING_SENTIMENT_COUNT)
@@ -261,7 +269,16 @@ class RedisManager:
             count = int(raw_count or 0) + 1
         except (TypeError, ValueError):
             count = 1
-        self.redis_set(REDIS_KEY_PENDING_SENTIMENT_COUNT, str(count))
+        # Refresh both expiries together so a complete candidate observation
+        # always has a bounded lifetime from its most recent evidence.
+        self.redis_setex(
+            REDIS_KEY_PENDING_SENTIMENT, _PENDING_SENTIMENT_TTL, sentiment
+        )
+        self.redis_setex(
+            REDIS_KEY_PENDING_SENTIMENT_COUNT,
+            _PENDING_SENTIMENT_TTL,
+            str(count),
+        )
         return count
 
     def clear_pending_sentiment(self) -> None:

--- a/src/orbit/core/sentimen_cron.py
+++ b/src/orbit/core/sentimen_cron.py
@@ -191,8 +191,9 @@ class Croner(ExceptionManager, RedisManager):
             cached = None
 
         if cached is None:
-            self.clear_pending_sentiment()
-            return observed, "initialized", 1
+            if self.set_market_sentiment_if_current(None, observed):
+                return observed, "initialized", 1
+            return self.get_market_sentiment(), "regime_changed_during_resolution", 0
 
         if observed == cached:
             self.clear_pending_sentiment()
@@ -202,14 +203,17 @@ class Croner(ExceptionManager, RedisManager):
             if score < self.neutral_confidence_threshold:
                 self.clear_pending_sentiment()
                 return cached, "neutral_rejected_low_confidence", 0
-            confirmations = self.record_pending_sentiment(observed, cached)
-            if confirmations is None:
+            confirmation = self.record_pending_sentiment(
+                observed, cached, self.neutral_confirmations_required
+            )
+            if confirmation is None:
                 return (
                     self.get_market_sentiment(),
                     "regime_changed_during_resolution",
                     0,
                 )
-            if confirmations < self.neutral_confirmations_required:
+            confirmations, was_committed = confirmation
+            if not was_committed:
                 return cached, "neutral_pending_confirmation", confirmations
             return observed, "neutral_confirmed", confirmations
 
@@ -217,7 +221,9 @@ class Croner(ExceptionManager, RedisManager):
             self.clear_pending_sentiment()
             return cached, "directional_rejected_low_confidence", 0
 
-        return observed, "directional_change", 1
+        if self.set_market_sentiment_if_current(cached, observed):
+            return observed, "directional_change", 1
+        return self.get_market_sentiment(), "regime_changed_during_resolution", 0
 
     async def run_once(self) -> Dict[str, Any]:
         """Execute a single full sentiment-analysis cycle.
@@ -255,19 +261,6 @@ class Croner(ExceptionManager, RedisManager):
             description=None,
             fields=result,
         )
-
-        try:
-            if effective_sentiment is not None and signal_action in {
-                "initialized",
-                "neutral_confirmed",
-                "directional_change",
-            }:
-                self.set_market_sentiment_and_clear_pending(effective_sentiment)
-        except Exception as e:
-            self.handle_exception(
-                e,
-                context_description="Failed to update Redis after full analysis",
-            )
 
         return result
 

--- a/src/orbit/core/sentimen_cron.py
+++ b/src/orbit/core/sentimen_cron.py
@@ -203,16 +203,20 @@ class Croner(ExceptionManager, RedisManager):
                 self.clear_pending_sentiment()
                 return cached, "neutral_rejected_low_confidence", 0
             confirmations = self.record_pending_sentiment(observed, cached)
+            if confirmations is None:
+                return (
+                    self.get_market_sentiment(),
+                    "regime_changed_during_resolution",
+                    0,
+                )
             if confirmations < self.neutral_confirmations_required:
                 return cached, "neutral_pending_confirmation", confirmations
-            self.clear_pending_sentiment()
             return observed, "neutral_confirmed", confirmations
 
         if score < self.sentiment_drift_threshold:
             self.clear_pending_sentiment()
             return cached, "directional_rejected_low_confidence", 0
 
-        self.clear_pending_sentiment()
         return observed, "directional_change", 1
 
     async def run_once(self) -> Dict[str, Any]:
@@ -253,8 +257,12 @@ class Croner(ExceptionManager, RedisManager):
         )
 
         try:
-            if effective_sentiment is not None:
-                self.set_market_sentiment(effective_sentiment)
+            if effective_sentiment is not None and signal_action in {
+                "initialized",
+                "neutral_confirmed",
+                "directional_change",
+            }:
+                self.set_market_sentiment_and_clear_pending(effective_sentiment)
         except Exception as e:
             self.handle_exception(
                 e,
@@ -370,8 +378,9 @@ class Croner(ExceptionManager, RedisManager):
                     "Triggering immediate full analysis."
                 )
                 try:
-                    self.clear_pending_sentiment()
-                    self.set_market_sentiment(news_sentiment.sentiment)
+                    self.set_market_sentiment_and_clear_pending(
+                        news_sentiment.sentiment
+                    )
                 except Exception as e:
                     logger.exception("Failed to update Redis after incremental analysis.")
                     self.handle_exception(

--- a/src/orbit/core/sentimen_cron.py
+++ b/src/orbit/core/sentimen_cron.py
@@ -38,6 +38,12 @@ NEWS_POLL_INTERVAL_SECONDS: int = 600  # 10 minutes
 # immediate full analysis.
 SENTIMENT_DRIFT_THRESHOLD: float = 0.55
 
+# A directional regime is useful until the market repeatedly demonstrates that
+# its edge has disappeared. One neutral observation is often just an uneventful
+# news window, so require two credible observations before clearing the signal.
+NEUTRAL_CONFIDENCE_THRESHOLD: float = 0.60
+NEUTRAL_CONFIRMATIONS_REQUIRED: int = 2
+
 # How long a drift window lasts before the counter is reset (seconds)
 DRIFT_WINDOW_SECONDS: int = 86_400  # 24 hours
 
@@ -55,6 +61,10 @@ class Croner(ExceptionManager, RedisManager):
         news_poll_interval: Override the news-polling interval in seconds.
         sentiment_drift_threshold: Override the confidence threshold that
             triggers an immediate full analysis on sentiment drift.
+        neutral_confidence_threshold: Minimum confidence for a neutral
+            observation to count toward clearing a directional signal.
+        neutral_confirmations_required: Consecutive credible neutral hourly
+            observations required before the cached signal becomes neutral.
         legacy_updates_enabled: Enable the legacy 10-minute source poller.
     """
 
@@ -65,6 +75,8 @@ class Croner(ExceptionManager, RedisManager):
         custom_logger: Optional[logging.Logger] = None,
         news_poll_interval: int = NEWS_POLL_INTERVAL_SECONDS,
         sentiment_drift_threshold: float = SENTIMENT_DRIFT_THRESHOLD,
+        neutral_confidence_threshold: float = NEUTRAL_CONFIDENCE_THRESHOLD,
+        neutral_confirmations_required: int = NEUTRAL_CONFIRMATIONS_REQUIRED,
         legacy_updates_enabled: Optional[bool] = None,
     ) -> None:
         ExceptionManager.__init__(self, custom_logger)
@@ -78,6 +90,8 @@ class Croner(ExceptionManager, RedisManager):
 
         self.news_poll_interval: int = news_poll_interval
         self.sentiment_drift_threshold: float = sentiment_drift_threshold
+        self.neutral_confidence_threshold = neutral_confidence_threshold
+        self.neutral_confirmations_required = neutral_confirmations_required
         self.legacy_updates_enabled = (
             legacy_updates_enabled
             if legacy_updates_enabled is not None
@@ -153,13 +167,63 @@ class Croner(ExceptionManager, RedisManager):
     # FULL ANALYSIS
     # ------------------------------------------------------------------
 
+    def _resolve_effective_sentiment(
+        self, observed: Any, confidence: Any
+    ) -> tuple[Optional[str], str, int]:
+        """Apply confidence-aware regime hysteresis to an hourly observation.
+
+        Returns ``(effective_label, action, confirmation_count)``. Directional
+        signals can change on one sufficiently confident observation. Clearing a
+        directional signal to neutral requires consecutive credible observations,
+        preventing a quiet hour from erasing useful market intelligence.
+        """
+        labels = {"BULLISH", "BEARISH", "NEUTRAL"}
+        if observed not in labels:
+            return self.get_market_sentiment(), "invalid_observation", 0
+
+        try:
+            score = float(confidence)
+        except (TypeError, ValueError):
+            score = 0.0
+
+        cached = self.get_market_sentiment()
+        if cached not in labels:
+            cached = None
+
+        if cached is None:
+            self.clear_pending_sentiment()
+            return observed, "initialized", 1
+
+        if observed == cached:
+            self.clear_pending_sentiment()
+            return cached, "confirmed", 1
+
+        if observed == "NEUTRAL":
+            if score < self.neutral_confidence_threshold:
+                self.clear_pending_sentiment()
+                return cached, "neutral_rejected_low_confidence", 0
+            confirmations = self.record_pending_sentiment(observed)
+            if confirmations < self.neutral_confirmations_required:
+                return cached, "neutral_pending_confirmation", confirmations
+            self.clear_pending_sentiment()
+            return observed, "neutral_confirmed", confirmations
+
+        if score < self.sentiment_drift_threshold:
+            self.clear_pending_sentiment()
+            return cached, "directional_rejected_low_confidence", 0
+
+        self.clear_pending_sentiment()
+        return observed, "directional_change", 1
+
     async def run_once(self) -> Dict[str, Any]:
         """Execute a single full sentiment-analysis cycle.
 
         Returns:
             The analysis result dict.
         """
-        result = await self.sentimental_workflow.run_web_search_analysis()
+        # Work on our own envelope: test doubles and workflow callers may reuse
+        # the returned mapping, while the scheduler adds effective-signal metadata.
+        result = dict(await self.sentimental_workflow.run_web_search_analysis())
         logger.info(f"Sentiment Analysis Result: {result}")
         if not result.get("success"):
             logger.error("Hourly web-search sentiment failed: %s", result.get("error"))
@@ -169,9 +233,18 @@ class Croner(ExceptionManager, RedisManager):
         sentiment_reasoning = result.get("explanation")
         dominant_memory_sentiment = result.get("dominant_memory_sentiment")
 
+        effective_sentiment, signal_action, confirmation_count = (
+            self._resolve_effective_sentiment(sentiment, sentiment_confidence)
+        )
+        result["observed_sentiment"] = sentiment
+        result["effective_sentiment"] = effective_sentiment
+        result["signal_action"] = signal_action
+        result["confirmation_count"] = confirmation_count
+
         self.send_market_sentiment(
             data=(
-                f"Market Sentiment = {sentiment}, Confidence : {sentiment_confidence}, "
+                f"Observed Sentiment = {sentiment}, Effective Signal = {effective_sentiment}, "
+                f"Confidence: {sentiment_confidence}, Action: {signal_action}, "
                 f"Reasoning : {sentiment_reasoning} | "
                 f"Memory dominant: {dominant_memory_sentiment}"
             ),
@@ -180,7 +253,8 @@ class Croner(ExceptionManager, RedisManager):
         )
 
         try:
-            self.set_market_sentiment(sentiment)
+            if effective_sentiment is not None:
+                self.set_market_sentiment(effective_sentiment)
         except Exception as e:
             self.handle_exception(
                 e,

--- a/src/orbit/core/sentimen_cron.py
+++ b/src/orbit/core/sentimen_cron.py
@@ -202,7 +202,7 @@ class Croner(ExceptionManager, RedisManager):
             if score < self.neutral_confidence_threshold:
                 self.clear_pending_sentiment()
                 return cached, "neutral_rejected_low_confidence", 0
-            confirmations = self.record_pending_sentiment(observed)
+            confirmations = self.record_pending_sentiment(observed, cached)
             if confirmations < self.neutral_confirmations_required:
                 return cached, "neutral_pending_confirmation", confirmations
             self.clear_pending_sentiment()
@@ -370,6 +370,7 @@ class Croner(ExceptionManager, RedisManager):
                     "Triggering immediate full analysis."
                 )
                 try:
+                    self.clear_pending_sentiment()
                     self.set_market_sentiment(news_sentiment.sentiment)
                 except Exception as e:
                     logger.exception("Failed to update Redis after incremental analysis.")

--- a/src/orbit/market_intelligence/llm/prompt_manager.py
+++ b/src/orbit/market_intelligence/llm/prompt_manager.py
@@ -28,7 +28,9 @@ class PromptManager:
     # Local prompt templates (identical to the current hard‑coded prompts)
     # ------------------------------------------------------------------
     _LOCAL_TEMPLATES = {
-        "hourly_web_search_sentiment": (
+        # Version the production prompt name so an older Langfuse prompt cannot
+        # silently override these signal-quality rules after deployment.
+        "hourly_web_search_sentiment_v2": (
             "You are Orbit's institutional market-intelligence analyst. The current "
             "UTC time is {current_time_utc}. Use live web search to assess information "
             "published or materially updated during the last four hours.\n\n"
@@ -38,13 +40,20 @@ class PromptManager:
             "- futures funding, open interest, liquidations, basis, leverage, and exchange incidents\n"
             "- geopolitical or macro events with immediate risk-on/risk-off impact\n\n"
             "Use credible, recent sources. Treat rumors and unsupported social posts as noise. "
-            "Do not infer a directional signal when evidence is stale, mixed, or immaterial. "
+            "Assess the expected direction for risk assets over the next 4-12 hours. Weight "
+            "market-moving evidence by recency, source quality, breadth across assets, and likely "
+            "price impact. Distinguish genuinely balanced evidence from a quiet news window: use "
+            "NEUTRAL only when credible bullish and bearish forces are balanced or there is no "
+            "tradable directional edge. A modest but coherent net edge should be BULLISH or "
+            "BEARISH with appropriately modest confidence. Do not manufacture direction from "
+            "stale, duplicated, speculative, or immaterial items. "
             "This is a market sentiment input, not an instruction to place a trade.\n\n"
             "Return ONLY valid JSON with this exact shape and no markdown:\n"
             "{{\n"
             '  "sentiment": "BULLISH" | "BEARISH" | "NEUTRAL",\n'
             '  "confidence": <float from 0.0 to 1.0>,\n'
-            '  "explanation": "concise evidence-based synthesis",\n'
+            '  "explanation": "2-4 sentences naming the dominant catalysts, counter-evidence, '
+            'affected assets, and 4-12 hour risk",\n'
             '  "sources": ["https://source.example/article"]\n'
             "}}\n"
             "Include 2-8 source URLs actually consulted."

--- a/src/orbit/market_intelligence/sentimental_workflow.py
+++ b/src/orbit/market_intelligence/sentimental_workflow.py
@@ -860,7 +860,7 @@ class SentimentWorkflow(ExceptionManager):
         try:
             current_time = datetime.now(timezone.utc).isoformat()
             prompt = self.prompt_manager.get_prompt(
-                "hourly_web_search_sentiment", current_time_utc=current_time
+                "hourly_web_search_sentiment_v2", current_time_utc=current_time
             )
             raw_content = self.llm.invoke_web_search(prompt)
             data = extract_json(str(raw_content))

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -68,6 +68,9 @@ class TestCore(unittest.TestCase):
         state = {"market_sentiments": "BULLISH"}
         mock_redis.get.side_effect = lambda key: state.get(key)
         mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
+        mock_redis.setex.side_effect = (
+            lambda key, _ttl, value: state.__setitem__(key, value)
+        )
         mock_redis.delete.side_effect = lambda key: state.pop(key, None)
         croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
 
@@ -91,6 +94,9 @@ class TestCore(unittest.TestCase):
         state = {"market_sentiments": "BEARISH"}
         mock_redis.get.side_effect = lambda key: state.get(key)
         mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
+        mock_redis.setex.side_effect = (
+            lambda key, _ttl, value: state.__setitem__(key, value)
+        )
         mock_redis.delete.side_effect = lambda key: state.pop(key, None)
         croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
 
@@ -101,6 +107,36 @@ class TestCore(unittest.TestCase):
         self.assertEqual(second["effective_sentiment"], "NEUTRAL")
         self.assertEqual(second["signal_action"], "neutral_confirmed")
         self.assertEqual(state["market_sentiments"], "NEUTRAL")
+
+    @timeout(30)
+    def test_expired_neutral_observation_cannot_confirm_later_result(self):
+        workflow = MagicMock()
+        workflow.run_web_search_analysis = AsyncMock(return_value={
+            "success": True,
+            "sentiment": "NEUTRAL",
+            "confidence": 0.72,
+            "explanation": "Directional catalysts are balanced.",
+        })
+        mock_redis = MagicMock()
+        state = {"market_sentiments": "BEARISH"}
+        mock_redis.get.side_effect = lambda key: state.get(key)
+        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
+        mock_redis.setex.side_effect = (
+            lambda key, _ttl, value: state.__setitem__(key, value)
+        )
+        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
+
+        first = asyncio.run(croner.run_once())
+        # Simulate Redis expiring the pending evidence during an analysis outage.
+        state.pop("sentiment:pending_label")
+        state.pop("sentiment:pending_count")
+        recovered = asyncio.run(croner.run_once())
+
+        self.assertEqual(first["signal_action"], "neutral_pending_confirmation")
+        self.assertEqual(recovered["signal_action"], "neutral_pending_confirmation")
+        self.assertEqual(recovered["confirmation_count"], 1)
+        self.assertEqual(state["market_sentiments"], "BEARISH")
 
     @timeout(30)
     def test_low_confidence_directional_flip_is_rejected(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -130,12 +130,44 @@ class TestCore(unittest.TestCase):
         first = asyncio.run(croner.run_once())
         # Simulate Redis expiring the pending evidence during an analysis outage.
         state.pop("sentiment:pending_label")
+        state.pop("sentiment:pending_base")
         state.pop("sentiment:pending_count")
         recovered = asyncio.run(croner.run_once())
 
         self.assertEqual(first["signal_action"], "neutral_pending_confirmation")
         self.assertEqual(recovered["signal_action"], "neutral_pending_confirmation")
         self.assertEqual(recovered["confirmation_count"], 1)
+        self.assertEqual(state["market_sentiments"], "BEARISH")
+
+    @timeout(30)
+    def test_pending_neutral_does_not_cross_directional_regimes(self):
+        workflow = MagicMock()
+        workflow.run_web_search_analysis = AsyncMock(return_value={
+            "success": True,
+            "sentiment": "NEUTRAL",
+            "confidence": 0.72,
+            "explanation": "Directional catalysts are balanced.",
+        })
+        mock_redis = MagicMock()
+        state = {"market_sentiments": "BULLISH"}
+        mock_redis.get.side_effect = lambda key: state.get(key)
+        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
+        mock_redis.setex.side_effect = (
+            lambda key, _ttl, value: state.__setitem__(key, value)
+        )
+        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
+
+        first = asyncio.run(croner.run_once())
+        # Simulate another supported update path establishing a newer regime.
+        state["market_sentiments"] = "BEARISH"
+        after_regime_change = asyncio.run(croner.run_once())
+
+        self.assertEqual(first["confirmation_count"], 1)
+        self.assertEqual(after_regime_change["confirmation_count"], 1)
+        self.assertEqual(
+            after_regime_change["signal_action"], "neutral_pending_confirmation"
+        )
         self.assertEqual(state["market_sentiments"], "BEARISH")
 
     @timeout(30)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -55,6 +55,74 @@ class TestCore(unittest.TestCase):
         self.assertFalse(result["success"])
         mock_redis.set.assert_not_called()
 
+    @timeout(30)
+    def test_single_neutral_hour_preserves_directional_signal(self):
+        workflow = MagicMock()
+        workflow.run_web_search_analysis = AsyncMock(return_value={
+            "success": True,
+            "sentiment": "NEUTRAL",
+            "confidence": 0.72,
+            "explanation": "The latest catalysts are balanced.",
+        })
+        mock_redis = MagicMock()
+        state = {"market_sentiments": "BULLISH"}
+        mock_redis.get.side_effect = lambda key: state.get(key)
+        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
+        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
+
+        result = asyncio.run(croner.run_once())
+
+        self.assertEqual(result["observed_sentiment"], "NEUTRAL")
+        self.assertEqual(result["effective_sentiment"], "BULLISH")
+        self.assertEqual(result["signal_action"], "neutral_pending_confirmation")
+        self.assertEqual(state["market_sentiments"], "BULLISH")
+
+    @timeout(30)
+    def test_repeated_credible_neutral_clears_directional_signal(self):
+        workflow = MagicMock()
+        workflow.run_web_search_analysis = AsyncMock(return_value={
+            "success": True,
+            "sentiment": "NEUTRAL",
+            "confidence": 0.72,
+            "explanation": "Directional catalysts remain balanced.",
+        })
+        mock_redis = MagicMock()
+        state = {"market_sentiments": "BEARISH"}
+        mock_redis.get.side_effect = lambda key: state.get(key)
+        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
+        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
+
+        first = asyncio.run(croner.run_once())
+        second = asyncio.run(croner.run_once())
+
+        self.assertEqual(first["effective_sentiment"], "BEARISH")
+        self.assertEqual(second["effective_sentiment"], "NEUTRAL")
+        self.assertEqual(second["signal_action"], "neutral_confirmed")
+        self.assertEqual(state["market_sentiments"], "NEUTRAL")
+
+    @timeout(30)
+    def test_low_confidence_directional_flip_is_rejected(self):
+        workflow = MagicMock()
+        workflow.run_web_search_analysis = AsyncMock(return_value={
+            "success": True,
+            "sentiment": "BEARISH",
+            "confidence": 0.41,
+            "explanation": "Weak downside evidence.",
+        })
+        mock_redis = MagicMock()
+        state = {"market_sentiments": "BULLISH"}
+        mock_redis.get.side_effect = lambda key: state.get(key)
+        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
+        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
+
+        result = asyncio.run(croner.run_once())
+
+        self.assertEqual(result["effective_sentiment"], "BULLISH")
+        self.assertEqual(result["signal_action"], "directional_rejected_low_confidence")
+
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -22,17 +22,31 @@ def _configure_sentiment_redis(mock_redis, state):
     mock_redis.delete.side_effect = lambda *keys: [state.pop(key, None) for key in keys]
 
     def eval_script(_script, _key_count, *args):
-        if len(args) == 7:  # atomic candidate update: four keys + three args
-            market_key, label_key, base_key, count_key, base, label, _ttl = args
+        if len(args) == 8:  # candidate update: four keys + four args
+            market_key, label_key, base_key, count_key, base, label, _ttl, required = args
             if state.get(market_key) != base:
-                return -1
+                return 0
             count = 1
             if state.get(label_key) == label and state.get(base_key) == base:
                 count = int(state.get(count_key, 0)) + 1
+            if count >= int(required):
+                state[market_key] = label
+                for key in (label_key, base_key, count_key):
+                    state.pop(key, None)
+                return -count
             state[label_key] = label
             state[base_key] = base
             state[count_key] = str(count)
             return count
+
+        if len(args) == 6:  # conditional regime transition: four keys + two args
+            market_key, label_key, base_key, count_key, expected, sentiment = args
+            if (state.get(market_key) or "") != expected:
+                return 0
+            state[market_key] = sentiment
+            for key in (label_key, base_key, count_key):
+                state.pop(key, None)
+            return 1
 
         market_key, label_key, base_key, count_key, sentiment = args
         state[market_key] = sentiment

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -14,6 +14,34 @@ from orbit.core.sentimen_cron import Croner
 
 patch("orbit.core.discord_manager.DiscordManager.send_to_webhook", return_value=None).start()
 
+
+def _configure_sentiment_redis(mock_redis, state):
+    """Model the atomic Redis scripts used by the sentiment scheduler."""
+    mock_redis.get.side_effect = lambda key: state.get(key)
+    mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
+    mock_redis.delete.side_effect = lambda *keys: [state.pop(key, None) for key in keys]
+
+    def eval_script(_script, _key_count, *args):
+        if len(args) == 7:  # atomic candidate update: four keys + three args
+            market_key, label_key, base_key, count_key, base, label, _ttl = args
+            if state.get(market_key) != base:
+                return -1
+            count = 1
+            if state.get(label_key) == label and state.get(base_key) == base:
+                count = int(state.get(count_key, 0)) + 1
+            state[label_key] = label
+            state[base_key] = base
+            state[count_key] = str(count)
+            return count
+
+        market_key, label_key, base_key, count_key, sentiment = args
+        state[market_key] = sentiment
+        for key in (label_key, base_key, count_key):
+            state.pop(key, None)
+        return 1
+
+    mock_redis.eval.side_effect = eval_script
+
 class TestCore(unittest.TestCase):
 
     @timeout(30)
@@ -37,7 +65,7 @@ class TestCore(unittest.TestCase):
         self.assertEqual(result["sentiment"], "BULLISH")
         self.assertEqual(result["confidence"], 0.9)
         self.assertEqual(result["reasoning"], "Strong buying pressure")
-        mock_redis.set.assert_any_call("market_sentiments", "BULLISH")
+        self.assertTrue(mock_redis.eval.called)
 
         assert result["sentiment"] == "BULLISH"
 
@@ -66,12 +94,7 @@ class TestCore(unittest.TestCase):
         })
         mock_redis = MagicMock()
         state = {"market_sentiments": "BULLISH"}
-        mock_redis.get.side_effect = lambda key: state.get(key)
-        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
-        mock_redis.setex.side_effect = (
-            lambda key, _ttl, value: state.__setitem__(key, value)
-        )
-        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        _configure_sentiment_redis(mock_redis, state)
         croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
 
         result = asyncio.run(croner.run_once())
@@ -92,12 +115,7 @@ class TestCore(unittest.TestCase):
         })
         mock_redis = MagicMock()
         state = {"market_sentiments": "BEARISH"}
-        mock_redis.get.side_effect = lambda key: state.get(key)
-        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
-        mock_redis.setex.side_effect = (
-            lambda key, _ttl, value: state.__setitem__(key, value)
-        )
-        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        _configure_sentiment_redis(mock_redis, state)
         croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
 
         first = asyncio.run(croner.run_once())
@@ -119,12 +137,7 @@ class TestCore(unittest.TestCase):
         })
         mock_redis = MagicMock()
         state = {"market_sentiments": "BEARISH"}
-        mock_redis.get.side_effect = lambda key: state.get(key)
-        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
-        mock_redis.setex.side_effect = (
-            lambda key, _ttl, value: state.__setitem__(key, value)
-        )
-        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        _configure_sentiment_redis(mock_redis, state)
         croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
 
         first = asyncio.run(croner.run_once())
@@ -150,12 +163,7 @@ class TestCore(unittest.TestCase):
         })
         mock_redis = MagicMock()
         state = {"market_sentiments": "BULLISH"}
-        mock_redis.get.side_effect = lambda key: state.get(key)
-        mock_redis.set.side_effect = lambda key, value: state.__setitem__(key, value)
-        mock_redis.setex.side_effect = (
-            lambda key, _ttl, value: state.__setitem__(key, value)
-        )
-        mock_redis.delete.side_effect = lambda key: state.pop(key, None)
+        _configure_sentiment_redis(mock_redis, state)
         croner = Croner(sentiment_workflow=workflow, redis_client=mock_redis)
 
         first = asyncio.run(croner.run_once())


### PR DESCRIPTION
## What changed

- add confidence-aware hysteresis before the hourly sentiment is persisted to Redis
- preserve an active BULLISH/BEARISH regime through a single neutral observation
- require two consecutive NEUTRAL observations at >= 0.60 confidence before clearing a directional signal
- reject low-confidence directional reversals below the existing 0.55 drift threshold
- expose observed sentiment, effective sentiment, transition action, and confirmation count in scheduler results and alerts
- upgrade and version the Codex web-search prompt around a 4-12 hour horizon, catalyst quality, counter-evidence, and market breadth

## Root cause

The hourly cron persisted every successful raw label directly. A quiet or mixed news window could therefore overwrite an actionable directional regime with NEUTRAL on the very next run, even when the evidence was weak.

## Impact

Signals now behave as market regimes instead of isolated hourly classifications. Directional changes remain responsive when confidence is sufficient, while neutralization needs repeated evidence. The versioned prompt also prevents an older Langfuse prompt from silently retaining the previous classification behavior.

## Validation

- `PYTHONPATH=/root/Orbit/src <venv>/bin/python -m pytest -q tests/test_core.py::TestCore tests/test_market_intelligence.py tests/test_market_intelligence_llm.py`
- 20 passed
- `git diff --check`
