### PR TITLE
chore: update pull request template with labeling instructions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,3 +12,23 @@ Brief description of the changes introduced in this PR.
 
 ## Related Issue
 Fixes #
+
+---
+
+## Labels Required
+Please ensure you add the appropriate labels to this PR before requesting a review. You must include at least one label from each of the following categories:
+
+**1. Module:**
+- `core`: Changes to the core engine, trading logic, or base architecture.
+- `market-intelligence`: Changes to the LLM, sentiment analysis, or external data gathering.
+- `strategy`: Addition or modification of specific asset trading strategies.
+
+**2. Type of PR:**
+- `enhancement`: New features or improvements.
+- `bug`: Bug fixes.
+- `won'tfix`: PRs that are being closed without being merged, or document a known unfixable issue.
+
+**3. Creator:**
+- `antigravity`: PR created by the Antigravity agent.
+- `codex`: PR created by Codex.
+- `claude`: PR created by Claude.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -27,6 +27,7 @@ Please ensure you add the appropriate labels to this PR before requesting a revi
 - `enhancement`: New features or improvements.
 - `bug`: Bug fixes.
 - `won'tfix`: PRs that are being closed without being merged, or document a known unfixable issue.
+- etc.
 
 **3. Creator:**
 - `antigravity`: PR created by the Antigravity agent.


### PR DESCRIPTION
## Summary
Updates the `.github/pull_request_template.md` to instruct users/bots to include mandatory labels on PR creation.

---

## Changes
- Added Module labels: `core`, `market-intelligence`, `strategy`
- Added Type labels: `enhancement`, `bug`, `won'tfix`, `etc.`
- Added Creator labels: `antigravity`, `codex`, `claude`

---

## Related Issue
Fixes #none