### PR TITLE
fix: validate paper orders without failure noise

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ REDIS_HOST=localhost
 REDIS_PORT=6379
 REDIS_DB=0
 ORBIT_LOG_FILE=app.log
+# Synthetic equity used to size and validate paper orders without submission.
+ORBIT_PAPER_EQUITY=10000
 
 # Market intelligence uses a provisioned Codex CLI auth.json file.
 OPENAI_AUTH_FILE=/run/secrets/codex/auth.json

--- a/docs/operations/SAFE_ADAPTIVE_TRADING.md
+++ b/docs/operations/SAFE_ADAPTIVE_TRADING.md
@@ -41,6 +41,13 @@ Testnet and production credentials must be different and should be loaded from
 AWS Systems Manager Parameter Store or Secrets Manager by the EC2 service. Never
 write credentials or webhook URLs into Git.
 
+Paper signals never submit an exchange order. They run the same stop/target,
+position-size, exchange-filter, and risk-policy checks against
+`ORBIT_PAPER_EQUITY`. Successful preflights are written to the decision ledger
+as `paper_validated` without failure alerts. A failed preflight records and alerts
+its actionable reason; unresolved failures are promotion blockers for Testnet or
+live configuration.
+
 ## Decision ledger
 
 MongoDB collection `trade_decisions` stores accepted, rejected, no-signal, and

--- a/src/orbit/core/main.py
+++ b/src/orbit/core/main.py
@@ -234,6 +234,28 @@ class BinanceAutomation(ExceptionManager):
 
         logger.info(f"Placing {action} order for {symbol}...")
 
+        if self.order_manager.execution_settings.mode_for(symbol) is ExecutionMode.PAPER:
+            preflight = self.order_manager.preflight_paper_order(
+                self.risk_management, symbol, action, price_to_use,
+                stop_loss, target, leverage,
+            )
+            event = {
+                "status": preflight.reason,
+                "request": preflight.request,
+                "metrics": preflight.metrics,
+            }
+            if decision_id and self.order_manager.mongo_handler is not None:
+                self.order_manager.mongo_handler.append_decision_event(decision_id, event)
+            if preflight.allowed:
+                logger.info("Paper order validated for %s: %s", symbol, preflight.request)
+            else:
+                self.send_alerts(
+                    data=None,
+                    description=f"Paper preflight failed for {symbol}: {preflight.reason}",
+                    fields=event,
+                )
+            return
+
         order_response, quantity, order_request = self.order_manager.place_order(
             self.risk_management,
             symbol,

--- a/src/orbit/core/order_manager.py
+++ b/src/orbit/core/order_manager.py
@@ -17,6 +17,9 @@ through the constructor for easier testing and looser coupling.
 
 import time
 import logging
+import os
+from dataclasses import dataclass
+from decimal import Decimal
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -32,6 +35,15 @@ from orbit.core.risk_manager import PreTradeRiskGuard
 from orbit.core.performance import PerformanceTracker
 
 logger = logging.getLogger("Orbit")
+
+
+@dataclass(frozen=True)
+class OrderPreflight:
+    """Result of validating an order without submitting it."""
+    allowed: bool
+    reason: str
+    request: Dict[str, Any]
+    metrics: Dict[str, Any]
 
 
 class OrderManager(AuthenticationManager, RedisManager):
@@ -127,15 +139,15 @@ class OrderManager(AuthenticationManager, RedisManager):
         if not price_filter:
             return price
 
-        tick = float(price_filter["tickSize"])
-        min_price = float(price_filter["minPrice"])
+        tick = Decimal(str(price_filter["tickSize"]))
+        min_price = Decimal(str(price_filter["minPrice"]))
+        price_value = max(Decimal(str(price)), min_price)
 
-        price = max(price, min_price)
         if tick <= 0:
-            return price
+            return float(price_value)
 
-        corrected = price - (price % tick)
-        return round(corrected, 8)
+        corrected = price_value - (price_value % tick)
+        return round(float(corrected), 8)
 
     def adjust_quantity_step(self, symbol: str, qty: float) -> float:
         """Round *qty* down to the nearest valid step size for *symbol*."""
@@ -144,15 +156,15 @@ class OrderManager(AuthenticationManager, RedisManager):
         if not lot_size:
             return qty
 
-        step = float(lot_size["stepSize"])
-        min_qty = float(lot_size["minQty"])
+        step = Decimal(str(lot_size["stepSize"]))
+        min_qty = Decimal(str(lot_size["minQty"]))
+        qty_value = max(Decimal(str(qty)), min_qty)
 
-        qty = max(qty, min_qty)
         if step <= 0:
-            return qty
+            return float(qty_value)
 
-        corrected = qty - (qty % step)
-        return round(corrected, 8)
+        corrected = qty_value - (qty_value % step)
+        return round(float(corrected), 8)
 
     def validate_notional(self, symbol: str, price: float, qty: float) -> bool:
         """Return ``True`` if ``price * qty`` meets the MIN_NOTIONAL filter."""
@@ -448,6 +460,60 @@ class OrderManager(AuthenticationManager, RedisManager):
         logger.info(f"Calculated position size for {symbol}: Qty={qty}, Required Margin={required_margin}")
         return qty, required_margin
 
+    def preflight_paper_order(
+        self, risk_management: Dict[str, Any], symbol: str, side: str,
+        price: Optional[float], sl: Optional[float], target: Optional[float],
+        leverage: int,
+    ) -> OrderPreflight:
+        """Run production risk and exchange-filter checks without submitting."""
+        request = {
+            "symbol": symbol, "side": side, "price": price,
+            "stop_loss": sl, "take_profit": target, "leverage": leverage,
+        }
+        try:
+            if price is None or sl is None:
+                return OrderPreflight(False, "missing_entry_or_stop", request, {})
+            if symbol not in risk_management:
+                return OrderPreflight(False, "missing_symbol_risk", request, {})
+
+            equity = float(os.getenv("ORBIT_PAPER_EQUITY", "10000"))
+            entry_price = self.adjust_price_tick(symbol, float(price))
+            stop_loss = float(sl)
+            take_profit = float(target) if target is not None else None
+            stop_distance = abs(entry_price - stop_loss)
+            if equity <= 0 or stop_distance <= 0:
+                return OrderPreflight(False, "invalid_paper_equity_or_stop", request, {})
+
+            risk_fraction = min(
+                float(risk_management[symbol]), self.risk_guard.max_risk_per_trade_pct
+            )
+            precision = self.config["trading_pairs_precision"][symbol]
+            quantity = self.adjust_quantity_step(
+                symbol, round((equity * risk_fraction) / stop_distance, precision)
+            )
+            request.update({"price": entry_price, "quantity": quantity})
+            decision = self.risk_guard.evaluate(
+                equity=equity, entry_price=entry_price, stop_loss=stop_loss,
+                take_profit=take_profit, quantity=quantity, leverage=leverage,
+                side=side,
+            )
+            if not decision.allowed:
+                return OrderPreflight(False, decision.reason, request, decision.metrics)
+            if not self.validate_notional(symbol, entry_price, quantity):
+                return OrderPreflight(
+                    False, "notional_below_exchange_minimum", request, decision.metrics
+                )
+            return OrderPreflight(True, "paper_validated", request, decision.metrics)
+        except (KeyError, TypeError, ValueError) as error:
+            logger.warning("Paper preflight configuration failed for %s: %s", symbol, error)
+            return OrderPreflight(False, "invalid_order_configuration", request, {})
+        except Exception as error:
+            logger.exception("Paper preflight failed for %s", symbol)
+            return OrderPreflight(
+                False, "preflight_dependency_error", request,
+                {"error_type": type(error).__name__},
+            )
+
     def place_order(
         self,
         risk_management: Dict[str, Any],
@@ -493,12 +559,7 @@ class OrderManager(AuthenticationManager, RedisManager):
 
             execution_mode = self.execution_settings.mode_for(symbol)
             if execution_mode is ExecutionMode.PAPER:
-                logger.warning("Order blocked: %s is configured for paper mode", symbol)
-                self.send_alerts(
-                    data=None,
-                    description="Order blocked in paper mode",
-                    fields={"symbol": symbol, "side": side},
-                )
+                logger.info("Order submission skipped: %s is configured for paper mode", symbol)
                 return None, None, None
 
             effective_trade_id = trade_id or symbol

--- a/tests/test_order_lifecycle.py
+++ b/tests/test_order_lifecycle.py
@@ -8,13 +8,13 @@ from orbit.core.order_manager import OrderManager
 from orbit.core.trade_checker import TradeChecker, is_stop_order, is_take_profit_order
 
 
-def _order_manager():
+def _order_manager(mode=ExecutionMode.TESTNET):
     manager = OrderManager(
         mongo_handler=MagicMock(),
         redis_client=MagicMock(),
         spot_client=MagicMock(),
         futures_client=MagicMock(),
-        execution_settings=ExecutionSettings({"BTCUSDT": ExecutionMode.TESTNET}),
+        execution_settings=ExecutionSettings({"BTCUSDT": mode}),
     )
     manager.config["trading_pairs_precision"]["BTCUSDT"] = 3
     manager.get_symbol_filters = MagicMock(
@@ -35,6 +35,7 @@ class TestOrderManager(unittest.TestCase):
 
     def test_exchange_filter_normalization(self):
         self.assertEqual(self.manager.adjust_price_tick("BTCUSDT", 12.34), 12.3)
+        self.assertEqual(self.manager.adjust_price_tick("BTCUSDT", 100.0), 100.0)
         self.assertEqual(self.manager.adjust_quantity_step("BTCUSDT", 0.0056), 0.005)
         self.assertTrue(self.manager.validate_notional("BTCUSDT", 1000, 0.005))
         self.assertFalse(self.manager.validate_notional("BTCUSDT", 999, 0.005))
@@ -66,6 +67,27 @@ class TestOrderManager(unittest.TestCase):
         )
         self.assertEqual(response, {"algoId": 123})
         self.manager.redis_client.set.assert_called_once_with("order:123", "trade-1")
+
+    @patch.dict("os.environ", {"ORBIT_PAPER_EQUITY": "10000"})
+    def test_paper_preflight_runs_production_risk_checks_without_submission(self):
+        manager = _order_manager(ExecutionMode.PAPER)
+        result = manager.preflight_paper_order(
+            {"BTCUSDT": 0.01}, "BTCUSDT", "BUY", 100, 98, 104, 2
+        )
+
+        self.assertTrue(result.allowed)
+        self.assertEqual(result.reason, "paper_validated")
+        self.assertEqual(result.request["quantity"], 12.5)
+        manager.future_client.new_order.assert_not_called()
+
+    def test_paper_preflight_returns_actionable_risk_reason(self):
+        manager = _order_manager(ExecutionMode.PAPER)
+        result = manager.preflight_paper_order(
+            {"BTCUSDT": 0.01}, "BTCUSDT", "BUY", 100, 98, 99, 2
+        )
+
+        self.assertFalse(result.allowed)
+        self.assertEqual(result.reason, "target_on_wrong_side")
 
 
 class TestTradeChecker(unittest.TestCase):

--- a/tests/test_paper_automation.py
+++ b/tests/test_paper_automation.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest.mock import MagicMock
+
+from orbit.core.execution import ExecutionMode
+from orbit.core.main import BinanceAutomation
+from orbit.core.order_manager import OrderPreflight
+
+
+class TestPaperAutomation(unittest.TestCase):
+    def setUp(self):
+        self.automation = BinanceAutomation.__new__(BinanceAutomation)
+        self.automation.risk_management = {"PAXGUSDT": 0.01}
+        self.automation.future_leverage = 2
+        self.automation.order_manager = MagicMock()
+        self.automation.order_manager.execution_settings.mode_for.return_value = (
+            ExecutionMode.PAPER
+        )
+        self.automation.order_manager.mongo_handler = MagicMock()
+        self.automation.send_logs = MagicMock()
+        self.automation.send_alerts = MagicMock()
+        self.signal = {
+            "decision_id": "decision-1",
+            "symbol": "PAXGUSDT",
+            "signal": "BUY",
+            "entry_price": 2400.0,
+            "stop_loss": 2390.0,
+            "take_profit": 2430.0,
+        }
+
+    def test_valid_paper_signal_is_recorded_without_failure_alert(self):
+        self.automation.order_manager.preflight_paper_order.return_value = (
+            OrderPreflight(
+                True,
+                "paper_validated",
+                {"symbol": "PAXGUSDT", "quantity": 0.25},
+                {"risk_pct": 0.0025},
+            )
+        )
+
+        self.automation.process_signal(self.signal)
+
+        self.automation.order_manager.place_order.assert_not_called()
+        self.automation.send_alerts.assert_not_called()
+        event = self.automation.order_manager.mongo_handler.append_decision_event.call_args.args[
+            1
+        ]
+        self.assertEqual(event["status"], "paper_validated")
+
+    def test_genuine_paper_issue_is_alerted_and_recorded(self):
+        self.automation.order_manager.preflight_paper_order.return_value = (
+            OrderPreflight(
+                False,
+                "reward_risk_below_minimum",
+                {"symbol": "PAXGUSDT"},
+                {"reward_risk_ratio": 1.0},
+            )
+        )
+
+        self.automation.process_signal(self.signal)
+
+        self.automation.send_alerts.assert_called_once()
+        event = self.automation.order_manager.mongo_handler.append_decision_event.call_args.args[
+            1
+        ]
+        self.assertEqual(event["status"], "reward_risk_below_minimum")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- treat Paper mode as an automated pre-production validation path instead of an order failure
- run sizing, tick/step, notional, stop/target, leverage, reward/risk, and portfolio-risk checks without submitting to Binance
- record `paper_validated` or an actionable blocker reason in the decision ledger
- suppress failure alerts for valid paper signals while preserving alerts for genuine preflight defects
- fix floating-point exchange normalization that could move an already aligned price down one tick

## Safety

- Paper mode still cannot submit exchange orders
- Testnet/live authorization remains explicit per asset
- unresolved paper preflight failures are documented as promotion blockers
- synthetic sizing equity is configured with `ORBIT_PAPER_EQUITY`

## Validation

- `poetry run pytest -q` — 67 passed
- `poetry run mypy src/orbit/market_intelligence/*.py` — success
- pylint on touched source/tests — 10.00/10
- `git diff --check` — clean